### PR TITLE
More efficient-faster spawn fetching for pokedex page

### DIFF
--- a/core/process/data.loader.php
+++ b/core/process/data.loader.php
@@ -340,6 +340,14 @@ if(!empty($page)){
 			$max 		= $config->system->max_pokemon; 
 			$pokedex 	= new stdClass();
 			
+			$req 		= "SELECT COUNT(*) as total,pokemon_id FROM pokemon GROUP by pokemon_id ";
+                        $result 	= $mysqli->query($req);
+	                $data_array = array();
+	                
+	                while($data = $result->fetch_object()){
+	                  $data_array[$data->pokemon_id] = $data->total;
+	                };
+	                
 			for( $i= 1 ; $i <= $max ; $i++ ){
 				
 				$pokedex->$i				= new stdClass();
@@ -347,12 +355,7 @@ if(!empty($page)){
 				$pokedex->$i->permalink 	= 'pokemon/'.$i; 
 				$pokedex->$i->img			= 'core/pokemons/'.$i.'.png'; 
 				$pokedex->$i->name			= $pokemons->$i->name; 
-				
-				$req 		= "SELECT COUNT(*) as total FROM pokemon WHERE pokemon_id = '".$i."'";
-				$result 	= $mysqli->query($req);
-				$data 		= $result->fetch_object();
-				
-				$pokedex->$i->spawn			= $data->total; 
+				$pokedex->$i->spawn = isset($data_array[$i])? $data_array[$i] : 0;
 							
 			}
 					


### PR DESCRIPTION
Changed the process that the spawns of pokemon were fetched by the db. Was too slow and was making unnecessary requests to the database.
## Description

<!--- Describe your changes in detail -->
## Motivation and Context

It is far more efficient and much more faster.
## How Has This Been Tested?

In my local instance.
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
