### PR TITLE
Pokemon time fix. 

### DIFF
--- a/core/process/data.loader.php
+++ b/core/process/data.loader.php
@@ -7,9 +7,14 @@ $variables 	= realpath(dirname(__FILE__)).'/../json/variables.json';
 $config 	= json_decode(file_get_contents($variables)); 
 
 
+// Set default timezone
+// #####################
+date_default_timezone_set($config->system->timezone);
+
 
 // Manage Time Interval
 // #####################
+
 
 
 $time_interval  = strlen($config->system->time_inverval); 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Added a line to set the default timezone in `data.loader.php`
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

The timezone from `variables.json` was never used nor set, which causes the function `strtotime` to displaying a incorrect "last seen" time if it involved Daylight Saving Time. 

An +1 -1 offset in time due to DST might also cause the Pokemon counter being 0 or increasing incorrectly because of the extra hour incorrectly added to _despawn_ time.

Might also fix all the related issues in _thread_ #30 
## How Has This Been Tested?

Added the line and refreshed the Pokemon details page. Without it it showed an 1-hour offset because of DST, with it the time shows correctly.
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
