### PR TITLE
Enable Cache-Control and Compression in htaccess

### DIFF
--- a/htaccess
+++ b/htaccess
@@ -36,3 +36,8 @@ RewriteRule ^dashboard$					index.php?page=dashboard										[QSA,NC,L]
 RewriteRule ^pokemon/$					index.php?page=pokedex											[QSA,NC,L]
 RewriteRule ^pokemon$					index.php?page=pokedex											[QSA,NC,L]
 
+
+# Cache static files for one month
+<FilesMatch "\.(ico|jpg|jpeg|png|gif|js|css)$">
+	Header set Cache-Control "max-age=2628000, public"
+</FilesMatch>

--- a/htaccess
+++ b/htaccess
@@ -41,3 +41,10 @@ RewriteRule ^pokemon$					index.php?page=pokedex											[QSA,NC,L]
 <FilesMatch "\.(ico|jpg|jpeg|png|gif|js|css)$">
 	Header set Cache-Control "max-age=2628000, public"
 </FilesMatch>
+
+# Enable compression for large content
+<IfModule mod_deflate.c>
+	<IfModule mod_filter.c>
+		AddOutputFilterByType DEFLATE text/html text/plain text/css text/javascript application/x-javascript application/javascript application/json
+	</IfModule>
+</IfModule>


### PR DESCRIPTION
## Description

This PR enables Cache-Control for static files and compression in htaccess.

This reduces page size a lot!
In my case gym page is 95% smaller (1.2MB -> 50KB) and loads way faster.

Please review!
## Motivation and Context
- better performance
- save mobile bandwidth
- better google pagerank (+25 points)
## How Has This Been Tested?

locally
https://vserver.obihoernchen.net/pokemon/
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Performance improvement
