### PR TITLE
[WIP] Show mythic recent spawns only

### DIFF
--- a/core/json/translations.json
+++ b/core/json/translations.json
@@ -140,10 +140,10 @@
 		"PL": "<a href='https://www.facebook.com/pokemonfunPL/' target='_blank'><big>Polub nas na </big><br><strong>Facebooku!</strong></a>"
 	},
 	"RECENT_SPAWNS": {
-		"EN": "The most <strong>recent</strong> rare spawns",
+		"EN": "The most <strong>recent</strong> mythic spawns",
 		"FR": "Les apparitions <strong>récentes</strong>",
 		"ES": "Apariciones <strong>recientes</strong>",
-		"DE": "Die <strong>letzten</strong> seltenen Spawns",
+		"DE": "Die <strong>letzten</strong> sehr seltenen Spawns",
 		"PL": "Ostatnio <strong>pojawiły się</strong>"
 	},
 	"FIGHT_TITLE": {

--- a/core/json/translations.json
+++ b/core/json/translations.json
@@ -140,10 +140,10 @@
 		"PL": "<a href='https://www.facebook.com/pokemonfunPL/' target='_blank'><big>Polub nas na </big><br><strong>Facebooku!</strong></a>"
 	},
 	"RECENT_SPAWNS": {
-		"EN": "The most <strong>recent</strong> spawns",
+		"EN": "The most <strong>recent</strong> rare spawns",
 		"FR": "Les apparitions <strong>récentes</strong>",
 		"ES": "Apariciones <strong>recientes</strong>",
-		"DE": "Die <strong>letzten</strong> Spawns:",
+		"DE": "Die <strong>letzten</strong> seltenen Spawns",
 		"PL": "Ostatnio <strong>pojawiły się</strong>"
 	},
 	"FIGHT_TITLE": {

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -142,7 +142,7 @@ switch($request){
 	
 	case 'spawnlist_update':
 		
-		// Recent rare spawn
+		// Recent mythic spawn
 		// ------------
 		
 		$pokelist_file  = SYS_PATH.'/core/json/pokelist_EN.json';
@@ -150,16 +150,17 @@ switch($request){
 		$pokemons       = json_decode($pokemon_file);
 
 		// get all rare and mythic pokemon ids
-		$rare_pokemons	= array();
+		$mythic_pokemons = array();
 		foreach($pokemons as $id=>$pokemon) {
-			if ($pokemon->rarity === "Mythic" || $pokemon->rarity === "Rare") {
-				$rare_pokemons[] = $id;
+			// TODO: change this to $locales->DASHBOARD_MYTHIC->$lang once locale support is integrated
+			if ($pokemon->rarity === "Mythic") {
+				$mythic_pokemons[] = $id;
 			}
 		}
 
 		// get last rare or mythic pokemon
 		$req		= "SELECT pokemon_id FROM pokemon 
-				   WHERE pokemon_id IN (".implode(",", $rare_pokemons).") 
+				   WHERE pokemon_id IN (".implode(",", $mythic_pokemons).") 
 				   ORDER BY disappear_time DESC LIMIT 0,1";
 		$result 	= $mysqli->query($req);
 		$recents	= array(); 

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -142,23 +142,31 @@ switch($request){
 	
 	case 'spawnlist_update':
 		
-		// Recent spawn
+		// Recent rare spawn
 		// ------------
 		
-		$req 		= "SELECT pokemon_id FROM pokemon ORDER BY disappear_time DESC LIMIT 0,1";
+		$pokelist_file  = SYS_PATH.'/core/json/pokelist_EN.json';
+		$pokemon_file   = file_get_contents($pokelist_file);
+		$pokemons       = json_decode($pokemon_file);
+
+		// get all rare and mythic pokemon ids
+		$rare_pokemons	= array();
+		foreach($pokemons as $id=>$pokemon) {
+			if ($pokemon->rarity === "Mythic" || $pokemon->rarity === "Rare") {
+				$rare_pokemons[] = $id;
+			}
+		}
+
+		// get last rare or mythic pokemon
+		$req		= "SELECT pokemon_id FROM pokemon 
+				   WHERE pokemon_id IN (".implode(",", $rare_pokemons).") 
+				   ORDER BY disappear_time DESC LIMIT 0,1";
 		$result 	= $mysqli->query($req);
 		$recents	= array(); 
 		$data 		= $result->fetch_object();
 		$pokeid 	= $data->pokemon_id;
 		
-		$pokelist_file	= SYS_PATH.'/core/json/pokelist_EN.json'; 
-		$pokemon_file 	= file_get_contents($pokelist_file); 
-		$pokemons	= json_decode($pokemon_file);
-	
-		
-		
 		if($_GET['last_id'] != $pokeid){
-		
 			$html = '
 		
 			<div class="col-md-1 col-xs-4 pokemon-single" pokeid="'.$pokeid.'" style="display:none;">
@@ -172,7 +180,6 @@ switch($request){
 			
 			
 			echo $html; 
-		
 		}
 	
 	break; 

--- a/core/process/data.loader.php
+++ b/core/process/data.loader.php
@@ -597,19 +597,19 @@ else{
 	
 	
 	
-	// Recent rare spawns
+	// Recent mythic spawns
 	// ------------
 
 	// get all rare and mythic pokemon ids
-	$rare_pokemons  = array();
+	$mythic_pokemons  = array();
 	foreach($pokemons as $id=>$pokemon) {
-		if ($pokemon->rarity === "Mythic" || $pokemon->rarity === "Rare") {
-			$rare_pokemons[] = $id;
+		if ($pokemon->rarity === $locales->DASHBOARD_MYTHIC->$lang) {
+			$mythic_pokemons[] = $id;
 		}
 	}
 	
 	$req 		= "SELECT DISTINCT pokemon_id FROM pokemon
-			   WHERE pokemon_id IN (".implode(",", $rare_pokemons).")
+			   WHERE pokemon_id IN (".implode(",", $mythic_pokemons).")
 			   ORDER BY disappear_time DESC LIMIT 0,12";
 	$result 	= $mysqli->query($req);
 	$recents	= array(); 

--- a/core/process/data.loader.php
+++ b/core/process/data.loader.php
@@ -597,10 +597,20 @@ else{
 	
 	
 	
-	// Recent spawn
+	// Recent rare spawns
 	// ------------
+
+	// get all rare and mythic pokemon ids
+	$rare_pokemons  = array();
+	foreach($pokemons as $id=>$pokemon) {
+		if ($pokemon->rarity === "Mythic" || $pokemon->rarity === "Rare") {
+			$rare_pokemons[] = $id;
+		}
+	}
 	
-	$req 		= "SELECT DISTINCT pokemon_id FROM pokemon ORDER BY disappear_time DESC LIMIT 0,12";
+	$req 		= "SELECT DISTINCT pokemon_id FROM pokemon
+			   WHERE pokemon_id IN (".implode(",", $rare_pokemons).")
+			   ORDER BY disappear_time DESC LIMIT 0,12";
 	$result 	= $mysqli->query($req);
 	$recents	= array(); 
 	


### PR DESCRIPTION
I think it's more interesting to have some mythic pokemons in the recent spawn list.
All these pidgeys and rattatas are boring.
## Description

This will use rarity from `pokelist_XX.json` and the SQL will filter for mythic pokemon IDs.
## Motivation and Context

Make it more interesting
You may be able to catch a rare pokemon because of this ;)
## How Has This Been Tested?

locally with english and german: 
https://vserver.obihoernchen.net/pokemon_dev/
## Screenshots:

Before
![image](https://cloud.githubusercontent.com/assets/453508/19024464/719068c0-8904-11e6-8411-5d71170d7dc1.png)

After
![image](https://cloud.githubusercontent.com/assets/453508/19024458/6184cebc-8904-11e6-86b0-f9251233d361.png)
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Breaking change (fix or feature that would cause existing functionality to change)
## TODO
- Translations for other languages
- We really should improve this whole json translation/pokelist stuff :D See https://github.com/brusselopole/Worldopole/issues/81#issuecomment-250943283 as well.

What do you guys think about this PR? Let's discuss.
