### PR TITLE
Make home widget configurable

### DIFF
--- a/core/css/style.css
+++ b/core/css/style.css
@@ -221,14 +221,14 @@ Also private joke ;)
 	margin-bottom:2em;
 }
 
-.big-data p a {
+.big-data a {
 	color:#777;
 	transition:color .25s ease-in;
 }
 
-.big-data p a:hover {
+.big-data a:hover {
 	text-decoration:none;
-	color:#174391; 
+	color:#174391;
 }
 
 .big-data big {

--- a/core/json/translations.json
+++ b/core/json/translations.json
@@ -132,13 +132,6 @@
 		"DE": "aktiv in %s",
 		"PL": "aktywne w %s"
 	},
-	"WIDGET_FB_LIKE": {
-		"EN": "<a href='https://www.facebook.com/brusselopole/' target='_blank'><big>Like us on</big><br><strong>Facebook!</strong></a>",
-		"FR": "<a href='https://www.facebook.com/brusselopole/' target='_blank'><big>Likez nous sur</big><br><strong>Facebook!</strong></a>",
-		"ES": "<a href='https://www.facebook.com/brusselopole/' target='_blank'><big>Danos Me gusta en </big><br><strong>Facebook!</strong></a>",
-		"DE": "<a href='https://www.facebook.com/brusselopole/' target='_blank'><big>Like uns auf </big><br><strong>Facebook!</strong></a>",
-		"PL": "<a href='https://www.facebook.com/pokemonfunPL/' target='_blank'><big>Polub nas na </big><br><strong>Facebooku!</strong></a>"
-	},
 	"RECENT_SPAWNS": {
 		"EN": "The most <strong>recent</strong> spawns",
 		"FR": "Les apparitions <strong>récentes</strong>",

--- a/core/json/variables.examples.json
+++ b/core/json/variables.examples.json
@@ -15,7 +15,7 @@
 		"url"			:	"https://www.facebook.com/brusselopole/",
 		"image"			:	"core/img/smartphone.png",
 		"image_alt"		:	"Like us on FB",
-		"text"			:	"<big>Like us on</big><br><strong>Facebook!</strong>"
+		"text"			:	"<big>Like us on</big><br>Facebook!"
 	},
 	"system":{
 		"map_center_lat"	:	"50.844441",

--- a/core/json/variables.examples.json
+++ b/core/json/variables.examples.json
@@ -1,6 +1,5 @@
 {
 	"urls":{
-		"fb_url"		:	"https://www.facebook.com/brusselopole/",
 		"fb_valor"		:	"http://bit.ly/ValorBrussels",
 		"fb_mystic"		:	"http://bit.ly/MysticBrussels",
 		"fb_instinct"		:	"http://bit.ly/InstinctBrussels"
@@ -11,6 +10,12 @@
 		"logo_path"		:	"core/img/logo.jpg",
 		"site_title"		:	"We ❤️ <strong>Pokémon</strong> and Data",
 		"site_claim"		:	"Find all collected and proccessed data about PokémonGo in %s."
+	},
+	"homewidget":{
+		"url"			:	"https://www.facebook.com/brusselopole/",
+		"image"			:	"core/img/smartphone.png",
+		"image_alt"		:	"Like us on FB",
+		"text"			:	"<big>Like us on</big><br><strong>Facebook!</strong>"
 	},
 	"system":{
 		"map_center_lat"	:	"50.844441",

--- a/pages/home.page.php
+++ b/pages/home.page.php
@@ -14,25 +14,35 @@
 <div class="row area">
 
 	<div class="col-md-3 col-sm-6 col-xs-12 big-data"> <!-- LIVEMON -->
-		<a href="pokemon"><img src="core/img/pokeball.png" alt="Visit the <?= $config->infos->site_name ?> Pokedex" width=50 class="big-icon"></a>
-		<p><a href="pokemon"><big><strong class="total-pkm-js">0</strong> Pokémon</big><br> 
-		<?= sprintf($locales->WIDGET_POKEMON_SUB->$lang, $config->infos->city); ?></a></p>
+		<a href="pokemon">
+			<img src="core/img/pokeball.png" alt="Visit the <?= $config->infos->site_name ?> Pokedex" width=50 class="big-icon">
+			<p><big><strong class="total-pkm-js">0</strong> Pokémon</big><br>
+			<?= sprintf($locales->WIDGET_POKEMON_SUB->$lang, $config->infos->city); ?></p>
+		</a>
 	</div>
 
 	<div class="col-md-3 col-sm-6 col-xs-12 big-data" style="border-right:1px lightgray solid;border-left:1px lightgray solid;"> <!-- GYMS -->
-		<a href="gym"><img src="core/img/rocket.png" alt="Discover the <?= $config->infos->site_name ?> Gyms" width=50 class="big-icon"></a>
-		<p><a href="gym"><big><strong class="total-gym-js">0</strong> <?= $locales->GYMS->$lang ?></big><br> <?= $locales->WIDGET_GYM_SUB->$lang ?></a></p>
+		<a href="gym">
+			<img src="core/img/rocket.png" alt="Discover the <?= $config->infos->site_name ?> Gyms" width=50 class="big-icon">
+			<p><big><strong class="total-gym-js">0</strong> <?= $locales->GYMS->$lang ?></big><br>
+			<?= $locales->WIDGET_GYM_SUB->$lang ?></p>
+		</a>
 
 	</div>
 
 	<div class="col-md-3 col-sm-6 col-xs-12 big-data" style="border-right:1px lightgray solid;"> <!-- POKESTOPS -->
-		<a href="pokestops"><img src="core/img/lure-module.png" alt="Discover the <?= $config->infos->site_name ?> Pokéstops" width=50 class="big-icon"></a>
-		<p><a href="pokestops"><big><strong class="total-lure-js">0</strong> <?= $locales->LURES->$lang ?></big><br> <?= sprintf($locales->WIDGET_LURES_SUB->$lang, $config->infos->city); ?></a></p>
+		<a href="pokestops">
+			<img src="core/img/lure-module.png" alt="Discover the <?= $config->infos->site_name ?> Pokéstops" width=50 class="big-icon">
+			<p><big><strong class="total-lure-js">0</strong> <?= $locales->LURES->$lang ?></big><br>
+			<?= sprintf($locales->WIDGET_LURES_SUB->$lang, $config->infos->city); ?></p>
+		</a>
 	</div>
 
-	<div class="col-md-3 col-sm-6 col-xs-12 big-data"> <!-- ADVERTISING -->
-		<a href="<?= $config->urls->fb_url ?>" target="_blank"><img src="core/img/smartphone.png" alt="Like us on FB" width=50 class="big-icon"></a>
-		<p><?= $locales->WIDGET_FB_LIKE->$lang ?></p>
+	<div class="col-md-3 col-sm-6 col-xs-12 big-data">
+		<a href="<?= $config->homewidget->url ?>" target="_blank">
+			<img src="<?= $config->homewidget->image ?>" alt="<?= $config->homewidget->image_alt ?>" width=50 class="big-icon">
+			<p><?= $config->homewidget->text ?></p>
+		</a>
 	</div>
 
 </div>

--- a/pages/pokestops.page.php
+++ b/pages/pokestops.page.php
@@ -13,12 +13,12 @@
 <div class="row area">
 
 	<div class="col-md-6 col-sm-6 col-xs-12 big-data" style="border-right:1px lightgray solid;"> <!-- POKESTOPS -->
-		<a href="<?= HOST_URL ?>/pokemon"><img src="core/img/pokestop.png" alt="Pokestop" width=50 class="big-icon"></a>
+		<img src="core/img/pokestop.png" alt="Pokestop" width=50 class="big-icon">
 		<p><big><strong><?= $pokestop->total ?></strong> Pokestops</big><br> <?= sprintf($locales->INCITY->$lang, $config->infos->city); ?></p>
 	</div>
 
 	<div class="col-md-6 col-sm-6 col-xs-12 big-data"> <!-- LURED STOPS -->
-		<a href="<?= HOST_URL ?>/pokemon"><img src="core/img/lure-module.png" alt="Lured Pokestop" width=50 class="big-icon"></a>
+		<img src="core/img/lure-module.png" alt="Lured Pokestop" width=50 class="big-icon">
 		<p><big><strong><?= $pokestop->lured ?></strong> <?= $locales->LURES->$lang ?></big><br> <?= $locales->POKESTOPS_LURES->$lang ?></p>
 	</div>
 </div>


### PR DESCRIPTION
## Description

With this PR you can configure the content of the 4th column of the home page (Like us on FB) via variables.json.
And it combines double `<a>` tags for image and text to one.
I did a minor visual change: fe6a77b2fe2096c56547b36ef9f78e9ca26b0804

On top of that this PR removes strange links to pokemon page from pokestop page.
## Motivation and Context

Hardcoding custom stuff is no fun
## How Has This Been Tested?

locally
https://vserver.obihoernchen.net/pokemon/
## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
### **Users have to update their variables.json!**
