### PR TITLE
Gym InfoWindow arrow, encoding fixes and cleanup

### DIFF
--- a/core/css/style.css
+++ b/core/css/style.css
@@ -381,5 +381,5 @@ div#gymLastModified{
 }
 
 div#gymDefenders{
-	padding : 15px;
+	padding : 5px 15px 15px 15px;
 }

--- a/core/css/style.css
+++ b/core/css/style.css
@@ -317,24 +317,38 @@ div#gym_details_template_container {
 
 div#gymInfos{
 	position: relative;
-	width: 375px;
-	border-radius: 5px; 
+	width: 400px;
+	border-radius: 5px;
 	border: 2px solid grey;
 	z-index:9000;
 	background-color: #ffffff;
-	margin : 15px;
+	margin: 15px;
 }
 
-div#circleImage{
+div#circleImage:before {
+	content: "";
+	width: 0;
+	height: 0;
+	position: absolute;
+	left: 44px;
+	bottom: 100%;
+	border-left: 14px solid transparent;
+	border-right: 14px solid transparent;
+	border-bottom: 35px solid #fff;
+	pointer-events: none;
+}
+
+div#circleImage {
 	position: relative;
 	left:-30px;
 	top:-12.5px;
 	width: 125px;
 	height: 125px;
-	border-radius: 75px; 
+	border-radius: 75px;
 	background-size: cover;
 	border: 4px solid white;
-	box-shadow: 0px 0px 10px 0px rgba(0,0,0,1);
+	-webkit-filter: drop-shadow(0px 0px 5px rgba(0,0,0,1));
+	filter: drop-shadow(0px 0px 5px rgba(0,0,0,1));
 }
 
 div#gymName{

--- a/core/js/gym.maps.js
+++ b/core/js/gym.maps.js
@@ -54,7 +54,6 @@ function initMap() {
 								background: "",
 								width: "400px",
 						},
-					closeBoxMargin: "12px 4px 2px 2px",
 					closeBoxURL: "",
 					infoBoxClearance: new google.maps.Size(1, 1)
 				});

--- a/core/js/gym.maps.js
+++ b/core/js/gym.maps.js
@@ -47,7 +47,7 @@ function initMap() {
 				var infowindow = new InfoBox({
 					content: document.getElementById("gym_details_template"),
 					disableAutoPan: false,
-					pixelOffset: new google.maps.Size(-66, 10),
+					pixelOffset: new google.maps.Size(-65, 12),
 					zIndex: null,
 					boxStyle: {
 								background: "",

--- a/core/js/gym.maps.js
+++ b/core/js/gym.maps.js
@@ -47,8 +47,7 @@ function initMap() {
 				var infowindow = new InfoBox({
 					content: document.getElementById("gym_details_template"),
 					disableAutoPan: false,
-					maxWidth: 425,
-					pixelOffset: new google.maps.Size(-200, 0),
+					pixelOffset: new google.maps.Size(-66, 10),
 					zIndex: null,
 					boxStyle: {
 								background: "",
@@ -122,7 +121,6 @@ function setGymDetails(gym) {
 	$('#gym_details_template #gymLastModifiedDisplay').html(gym.gymDetails.gymInfos.last_modified);
 	var teamColor = gym.gymDetails.gymInfos.team == "1" ? '#0086ff':gym.gymDetails.gymInfos.team == "2" ? '#ff1a1a':gym.gymDetails.gymInfos.team == "3" ? '#ff960b':'white';
 	$('#gym_details_template #gymInfos').css("border-color", teamColor);
-	$('#gym_details_template #gymDefenders').css("border-color", teamColor);
-	
+
 	$('#gym_details_template').show();
 }

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -385,10 +385,10 @@ switch($request){
 		$result 	= $mysqli->query($req);
 		$gymData['gymDetails']['gymInfos'] = false;
 		while($data = $result->fetch_object()){
-			$gymData['gymDetails']['gymInfos']['name'] = utf8_encode($data->name);
-			$gymData['gymDetails']['gymInfos']['description'] =  utf8_encode($data->description);
-			$gymData['gymDetails']['gymInfos']['url'] = utf8_encode($data->url);
-			$gymData['gymDetails']['gymInfos']['points'] = utf8_encode($data->points);
+			$gymData['gymDetails']['gymInfos']['name'] = $data->name;
+			$gymData['gymDetails']['gymInfos']['description'] = $data->description;
+			$gymData['gymDetails']['gymInfos']['url'] = $data->url;
+			$gymData['gymDetails']['gymInfos']['points'] = $data->points;
 			$gymData['gymDetails']['gymInfos']['level'] = 0;
 			$gymData['gymDetails']['gymInfos']['last_modified'] = $data->last_modified;
 			$gymData['gymDetails']['gymInfos']['team'] = $data->team;
@@ -442,7 +442,7 @@ switch($request){
 			$i++;
 		}
 		
-		$gymData['infoWindow'] =  utf8_encode($gymData['infoWindow'].'</div>');
+		$gymData['infoWindow'] = $gymData['infoWindow'].'</div>';
 		$return = json_encode($gymData); 
 
 		echo $return;

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -422,7 +422,7 @@ switch($request){
 					<a href="pokemon/'.$data->pokemon_id.'">
 					<img src="core/pokemons/'.$data->pokemon_id.'.png" height="40" style="display:inline-block;margin-bottom:10px;" >
 					</a>
-					<p class="pkmn-name">CP: '.$data->cp.'</p>
+					<p class="pkmn-name">'.$data->cp.'</p>
 					<div class="progress" style="height: 6px; margin-bottom: 0px">
 						<div title="IV Stamina: '.$data->iv_stamina.'" class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="'.$data->iv_stamina.'" aria-valuemin="0" aria-valuemax="45" style="width: '.(((100/15)*$data->iv_stamina)/3).'%">
 							<span class="sr-only">Stamina IV : '.$data->iv_stamina.'</span>

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -422,8 +422,8 @@ switch($request){
 					<a href="pokemon/'.$data->pokemon_id.'">
 					<img src="core/pokemons/'.$data->pokemon_id.'.png" height="40" style="display:inline-block;margin-bottom:10px;" >
 					</a>
-					<p class="pkmn-name">CP: '.$data->cp.'</p>		
-					<div class="progress" style="height: 6px">
+					<p class="pkmn-name">CP: '.$data->cp.'</p>
+					<div class="progress" style="height: 6px; margin-bottom: 0px">
 						<div title="IV Stamina: '.$data->iv_stamina.'" class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="'.$data->iv_stamina.'" aria-valuemin="0" aria-valuemax="45" style="width: '.(((100/15)*$data->iv_stamina)/3).'%">
 							<span class="sr-only">Stamina IV : '.$data->iv_stamina.'</span>
 						</div>

--- a/pages/trainer.page.php
+++ b/pages/trainer.page.php
@@ -88,7 +88,7 @@ if ($trainer_name === "") { ?>
 					<a href="pokemon/<?= $pokemon->pokemon_id ?>">
 					<img src="core/pokemons/<?= $pokemon->pokemon_id ?>.png" class="img-responsive<?php echo $pokemon->active ? "" : " unseen"; ?>">
 					</a>
-					<p class="pkmn-name">CP: <?= $pokemon->cp ?></p>		
+					<p class="pkmn-name"><?= $pokemon->cp ?></p>
 					<div class="progress" style="height: 6px">
 						<div title="IV Stamina: <?= $pokemon->iv_stamina ?>" class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="<?= $pokemon->iv_stamina ?>" aria-valuemin="0" aria-valuemax="45" style="width: <?= ((100/15)*$pokemon->iv_stamina)/3 ?>%">
 							<span class="sr-only">Stamina IV : <?= $pokemon->iv_stamina ?></span>


### PR DESCRIPTION
- Add an Arrow with shadow + remove some stuff abd3d36 (Screenshot 1)
- Fix encoding issues 9c815f4
- Remove unused parameter d936028
- Less margin 4bd180540a3d97a20f846ac9ad45a3fd2e870a34 (Screenshot 2)
- Remove "CP:" from trainer and gym infowindow. It looks more polished without. ad18c40c70971c441043624a1812364d39e48cc7 (Screenshot 2)

## Screenshots
**Arrow**
![image](https://cloud.githubusercontent.com/assets/453508/20334050/2e601ee4-ab85-11e6-9bf8-6c526bab51e7.png)

**+ all other improvements**
![image](https://cloud.githubusercontent.com/assets/453508/20336091/a76da5da-ab95-11e6-9095-0c4547436a68.png)

## Live
https://vserver.obihoernchen.net/pokemon_dev/gym

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)