### PR TITLE
Auto versioning for all custom css and js files

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -98,6 +98,19 @@ function file_datetime($file){
 	return $time; 
 }
 
+########################################################################
+// File version (unix timestamp)
+// @param $url		=> string (mandatory)
+//
+// Return $url with last_modified unix timestamp before suffix
+########################################################################
+
+function auto_ver($url){
+	$path = pathinfo($url);
+	$ver = '.'.filemtime(SYS_PATH.'/'.$url).'.';
+	echo $path['dirname'].'/'.preg_replace('/\.(css|js)$/', $ver."$1", $path['basename']);
+}
+
 if (!function_exists('http_response_code')) {
 	function http_response_code($code = NULL) {
 		if ($code !== NULL) {

--- a/htaccess
+++ b/htaccess
@@ -41,6 +41,9 @@ RewriteRule ^pokemon$			index.php?page=pokedex			[QSA,NC,L]
 	</FilesMatch>
 </IfModule>
 
+# Rules for Versioned Static Files
+RewriteRule ^core/(css|js)/(.+)\.(\d{10})\.(css|js)$ core/$1/$2.$4 [NC,L]
+
 # Enable compression for large content
 <IfModule mod_deflate.c>
 	<IfModule mod_filter.c>

--- a/index.php
+++ b/index.php
@@ -19,7 +19,7 @@ include_once('core/process/data.loader.php');
 		<link href="core/css/bootstrap.min.css" rel="stylesheet">
 		<link href="https://fonts.googleapis.com/css?family=Lato:400,300,700" rel="stylesheet" type="text/css">
 		<link href="core/css/font-awesome.min.css" rel="stylesheet">	
-		<link href="core/css/style.css" rel="stylesheet">
+		<link href="<?php auto_ver('core/css/style.css'); ?>" rel="stylesheet">
 
 		<!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
 		<!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
@@ -149,7 +149,7 @@ include_once('core/process/data.loader.php');
 		<?php // Load scripts only for page 
 		if (empty($page)) { ?>
 			
-			<script src="core/js/home.script.js"></script>
+			<script src="<?php auto_ver('core/js/home.script.js') ?>"></script>
 			
 			<script>
 				updateCounter(<?= $home->pokemon_now ?>,'.total-pkm-js');
@@ -179,7 +179,7 @@ include_once('core/process/data.loader.php');
 				
 				case 'pokestops': ?>
 				
-					<script src="core/js/pokestops.maps.js"></script>
+					<script src="<?php auto_ver('core/js/pokestops.maps.js') ?>"></script>
 					<script async defer src="https://maps.googleapis.com/maps/api/js?key=<?= $config->system->GMaps_Key ?>&libraries=visualization&callback=initMap"></script> 
 					
 					<?php
@@ -187,7 +187,7 @@ include_once('core/process/data.loader.php');
 					
 				case 'gym': ?>
 				
-					<script src="core/js/gym.script.js"></script>
+					<script src="<?php auto_ver('core/js/gym.script.js') ?>"></script>
 					<script>
 						updateCounter(<?= $teams->valor->gym_owned ?>,'.gym-valor-js');
 						updateCounter(<?= $teams->valor->average ?>,'.average-valor-js');
@@ -199,7 +199,7 @@ include_once('core/process/data.loader.php');
 						updateCounter(<?= $teams->mystic->average ?>,'.average-mystic-js');	
 					</script>
 			
-					<script src="core/js/gym.maps.js"></script>
+					<script src="<?php auto_ver('core/js/gym.maps.js') ?>"></script>
 					<script async defer src="https://maps.googleapis.com/maps/api/js?key=<?= $config->system->GMaps_Key ?>&libraries=visualization&callback=initMap"></script>
 				
 					<?php
@@ -227,7 +227,7 @@ include_once('core/process/data.loader.php');
 				case 'dashboard': ?>
 				
 					<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.2.1/Chart.min.js"></script>
-					<script src="core/js/dashboard.graph.js.php"></script>	
+					<script src="core/js/dashboard.graph.js.php"></script>
 
 					<?php
 					break;


### PR DESCRIPTION
This should fix all cache issues.

This will automatically append unix file mtime to each custom css and js file url like this: `style.1479310982.css`
So each time the file is changed the browser will get the new file automatically and cache it till there is another change (mtime changed --> name changed).

Please test :)

**You have to update your .htaccess!**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)