### PR TITLE
Fix redirect to offline if running in sub path

### DIFF
--- a/core/process/data.loader.php
+++ b/core/process/data.loader.php
@@ -36,7 +36,7 @@ $mysqli 	= new mysqli(SYS_DB_HOST, SYS_DB_USER, SYS_DB_PSWD, SYS_DB_NAME, SYS_DB
 
 if($mysqli->connect_error != ''){
 	
-	header('Location:/offline.html');
+	header('Location:'.HOST_URL.'offline.html');
 	exit();
 	
 }


### PR DESCRIPTION
## Description
DB error should properly redirect to static offline page
with a sub path is was redirecting to root

## Motivation and Context
Because I tried running it with a sub path

## How Has This Been Tested?
Local and remote server, both with and without subpath

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
