### PR TITLE
Time zone rework

### DIFF
--- a/core/cron/pokemon.cron.php
+++ b/core/cron/pokemon.cron.php
@@ -18,13 +18,13 @@ include_once($filePath.'/../process/locales.loader.php');
 $pokemon_stats['timestamp'] = $timestamp;
 
 
-$req 		= "SELECT COUNT(*) as total FROM pokemon WHERE disappear_time > (NOW() ".$time->symbol_reverse." INTERVAL ".$time->delay." HOUR)";
+$req 		= "SELECT COUNT(*) as total FROM pokemon WHERE disappear_time > UTC_TIMESTAMP()";
 $result 	= $mysqli->query($req);
 $data 		= $result->fetch_object();
 
 $pokemon_stats['pokemon_now'] 	= $data->total;
 
-$req 		= "SELECT pokemon_id FROM pokemon WHERE disappear_time > (NOW() ".$time->symbol_reverse." INTERVAL ".$time->delay." HOUR)";
+$req 		= "SELECT pokemon_id FROM pokemon WHERE disappear_time > UTC_TIMESTAMP()";
 $result 	= $mysqli->query($req);
 
 $rarityarray = array();

--- a/core/cron/pokestop.cron.php
+++ b/core/cron/pokestop.cron.php
@@ -15,7 +15,7 @@ $data 		= $result->fetch_object();
 
 $pokestop['total'] = $data->total;
 
-$req 		= "SELECT COUNT(*) as total FROM pokestop WHERE lure_expiration > (NOW() ".$time->symbol_reverse." INTERVAL ".$time->delay." HOUR)";
+$req 		= "SELECT COUNT(*) as total FROM pokestop WHERE lure_expiration > UTC_TIMESTAMP()";
 $result 	= $mysqli->query($req);
 $data 		= $result->fetch_object();
 

--- a/core/js/pokemon.graph.js.php
+++ b/core/js/pokemon.graph.js.php
@@ -31,20 +31,20 @@ if ($mysqli->connect_error != '') {
 
 $pokemon_id = mysqli_real_escape_string($mysqli, $_GET['id']);
 
-$req		= "SELECT COUNT(*) as total, HOUR(disappear_time ".$time->symbol." INTERVAL ".$time->delay." HOUR) as disappear_time 
-			FROM pokemon 
-			WHERE pokemon_id = '".$pokemon_id."' 
-			GROUP BY HOUR(disappear_time ".$time->symbol." INTERVAL ".$time->delay." HOUR) 
-			ORDER BY HOUR(disappear_time ".$time->symbol." INTERVAL ".$time->delay." HOUR), disappear_time";
+$req		= "SELECT COUNT(*) as total, HOUR(CONVERT_TZ(disappear_time, '+00:00', '".$time_offset."')) as disappear_hour
+			FROM pokemon
+			WHERE pokemon_id = '".$pokemon_id."'
+			GROUP BY disappear_hour
+			ORDER BY disappear_hour";
 		
 $result		= $mysqli->query($req);
 
 while ($data = $result->fetch_object()) {
-	if ($data->disappear_time < 10) {
-		$data->disappear_time = '0'.$data->disappear_time;
+	if ($data->disappear_hour < 10) {
+		$data->disappear_hour = '0'.$data->disappear_hour;
 	}
 	
-	$array[$data->disappear_time] = $data->total;
+	$array[$data->disappear_hour] = $data->total;
 }
 
 // Create the h24 array with associated values

--- a/core/json/variables.examples.json
+++ b/core/json/variables.examples.json
@@ -21,7 +21,6 @@
 		"map_center_lat"	:	"50.844441",
 		"map_center_long"	:	"4.363557",
 		"zoom_level"		:	"13",
-		"time_interval"		:	"+2",
 		"GMaps_Key"		:	"#GMAPS_KEY#",
 		"timezone"		:	"Europe/Paris",
 		"max_pokemon"		:	151,

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -259,7 +259,7 @@ switch ($request) {
 	
 	
 	case 'gym_map':
-		$req 		= "SELECT gym_id, team_id, guard_pokemon_id, gym_points, latitude, longitude, (last_modified ".$time->symbol." INTERVAL ".$time->delay." HOUR) as last_modified FROM gym";
+		$req 		= "SELECT gym_id, team_id, guard_pokemon_id, gym_points, latitude, longitude, (CONVERT_TZ(last_modified, '+00:00', '".$time_offset."')) as last_modified FROM gym";
 		$result 	= $mysqli->query($req);
 		
 		
@@ -369,7 +369,7 @@ switch ($request) {
 	
 	case 'gym_defenders':
 		$gym_id = $mysqli->real_escape_string($_GET['gym_id']);
-		$req 		= "SELECT gymdetails.name as name, gymdetails.description as description, gym.gym_points as points, gymdetails.url as url, gym.team_id as team, (gym.last_modified ".$time->symbol." INTERVAL ".$time->delay." HOUR) as last_modified, gym.guard_pokemon_id as guard_pokemon_id FROM gymdetails LEFT JOIN gym on gym.gym_id = gymdetails.gym_id WHERE gym.gym_id='".$gym_id."'";
+		$req 		= "SELECT gymdetails.name as name, gymdetails.description as description, gym.gym_points as points, gymdetails.url as url, gym.team_id as team, (CONVERT_TZ(gym.last_modified, '+00:00', '".$time_offset."')) as last_modified, gym.guard_pokemon_id as guard_pokemon_id FROM gymdetails LEFT JOIN gym on gym.gym_id = gymdetails.gym_id WHERE gym.gym_id='".$gym_id."'";
 		$result 	= $mysqli->query($req);
 		$gymData['gymDetails']['gymInfos'] = false;
 		while ($data = $result->fetch_object()) {

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -55,7 +55,7 @@ switch ($request) {
 		// Right now
 		// ---------
 		
-		$req 		= "SELECT COUNT(*) as total FROM pokemon WHERE disappear_time > (NOW() ".$time->symbol_reverse." INTERVAL ".$time->delay." HOUR);";
+		$req 		= "SELECT COUNT(*) as total FROM pokemon WHERE disappear_time > UTC_TIMESTAMP()";
 		$result 	= $mysqli->query($req);
 		$data 		= $result->fetch_object();
 		
@@ -65,7 +65,7 @@ switch ($request) {
 		// Lured stops
 		// -----------
 		
-		$req 		= "SELECT COUNT(*) as total FROM pokestop WHERE lure_expiration > (NOW() ".$time->symbol_reverse." INTERVAL ".$time->delay." HOUR);";
+		$req 		= "SELECT COUNT(*) as total FROM pokestop WHERE lure_expiration > UTC_TIMESTAMP()";
 		$result 	= $mysqli->query($req);
 		$data 		= $result->fetch_object();
 		

--- a/core/process/data.loader.php
+++ b/core/process/data.loader.php
@@ -185,7 +185,7 @@ if (!empty($page)) {
 						
 			// Last seen
 			
-			$req 		= "SELECT (disappear_time ".$time->symbol." INTERVAL ".$time->delay." HOUR) as disappear_time, latitude, longitude 
+			$req 		= "SELECT disappear_time, (CONVERT_TZ(disappear_time, '+00:00', '".$time_offset."')) as disappear_time_real, latitude, longitude
 			FROM pokemon 
 			WHERE pokemon_id = '".$pokemon_id."' 
 			ORDER BY disappear_time DESC 
@@ -196,7 +196,7 @@ if (!empty($page)) {
 			if (isset($data)) {
 				$last_spawn 				= $data;
 				
-				$pokemon->last_seen			= strtotime($data->disappear_time);
+				$pokemon->last_seen			= strtotime($data->disappear_time_real);
 				$pokemon->last_position			= new stdClass();
 				$pokemon->last_position->latitude 	= $data->latitude;
 				$pokemon->last_position->longitude 	= $data->longitude;

--- a/core/process/data.loader.php
+++ b/core/process/data.loader.php
@@ -280,7 +280,7 @@ if (!empty($page)) {
 			
 			$pokestop->total = $data->total;
 			
-			$req 		= "SELECT COUNT(*) as total FROM pokestop WHERE lure_expiration > (NOW() ".$time->symbol_reverse." INTERVAL ".$time->delay." HOUR)";
+			$req 		= "SELECT COUNT(*) as total FROM pokestop WHERE lure_expiration > UTC_TIMESTAMP()";
 			$result 	= $mysqli->query($req);
 			$data 		= $result->fetch_object();
 			
@@ -391,7 +391,7 @@ else {
 	// Right now
 	// ---------
 	
-	$req 		= "SELECT COUNT(*) as total FROM pokemon WHERE disappear_time > (NOW() ".$time->symbol_reverse." INTERVAL ".$time->delay." HOUR);";
+	$req 		= "SELECT COUNT(*) as total FROM pokemon WHERE disappear_time > UTC_TIMESTAMP()";
 	$result 	= $mysqli->query($req);
 	$data 		= $result->fetch_object();
 
@@ -402,7 +402,7 @@ else {
 	// Lured stops
 	// -----------
 	
-	$req 		= "SELECT COUNT(*) as total FROM pokestop WHERE lure_expiration > (NOW() ".$time->symbol_reverse." INTERVAL ".$time->delay." HOUR);";
+	$req 		= "SELECT COUNT(*) as total FROM pokestop WHERE lure_expiration > UTC_TIMESTAMP()";
 	$result 	= $mysqli->query($req);
 	$data 		= $result->fetch_object();
 	

--- a/core/process/data.loader.php
+++ b/core/process/data.loader.php
@@ -176,14 +176,6 @@ if (!empty($page)) {
 				$data		= $result->fetch_object();
 				
 				$pokemon->total_days = $data->total;
-				
-				
-				$req 		= "SELECT COUNT(*) as total, DATE(disappear_time ".$time->symbol." INTERVAL ".$time->delay." HOUR) as disappear_time
-				FROM pokemon WHERE pokemon_id = '".$pokemon_id."' 
-				GROUP BY DATE(disappear_time ".$time->symbol." INTERVAL ".$time->delay." HOUR) ";
-				
-				$result 	= $mysqli->query($req);
-				
 				$pokemon->spawn_rate 	= round(($pokemon->total_spawn/$pokemon->total_days), 2);
 			} else {
 				$pokemon->total_days 	= 0;

--- a/core/process/timezone.loader.php
+++ b/core/process/timezone.loader.php
@@ -12,23 +12,5 @@ if (!isset($config)) {
 // Set default timezone
 date_default_timezone_set($config->system->timezone);
 
-// Get symbol and delay
-$time_interval = strlen($config->system->time_interval);
-
-if ($time_interval > 3) {
-	echo 'Bad formated time_interval in variables.json. Please use +X or -X format only (eg for Brussels : +2) without leading or ending space.';
-	exit();
-}
-
-$time 		= new stdClass();
-$time->symbol	= substr($config->system->time_interval, 0, 1);
-$time->delay	= str_replace($time->symbol, '', $config->system->time_interval);
-
-if ($time->symbol == '+') {
-	$time->symbol_reverse = '-';
-} elseif ($time->symbol == '-') {
-	$time->symbol_reverse = '+';
-} else {
-	echo 'Bad formated time_interval in variables.json. Please use +X or -X format only (eg for Brussels : +2) without leading or ending space.';
-	exit();
-}
+// Get time offset to UTC in '+00:00' format
+$time_offset = date('P');

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,6 @@ SITE_NAME="Worldopole"
 CITY="Weuuurld"
 MAP_CENTER_LAT="50.844441"
 MAP_CENTER_LONG="4.363557"
-TIME_INTERVAL="+2"
 GMAPS_KEY=""
 TIMEZONE="Europe/Paris"
 
@@ -55,7 +54,6 @@ until [ "$answer" == 'y' ]; do
 	CITY=$(readinput "City Name: " "$CITY")
 	MAP_CENTER_LAT=$(readinput "Map Center Latitude: " "$MAP_CENTER_LAT")
 	MAP_CENTER_LONG=$(readinput "Map Center Longitude: " "$MAP_CENTER_LONG")
-	TIME_INTERVAL=$(readinput "Time Difference between Server Timezone and UTC (+/-hours): " "$TIME_INTERVAL")
 	GMAPS_KEY=$(readinput "GMaps API Key: " "$GMAPS_KEY")
 	TIMEZONE=$(readinput "Server Timezone (see http://php.net/manual/en/timezones.php): " "$TIMEZONE")
 
@@ -75,7 +73,6 @@ until [ "$answer" == 'y' ]; do
 	echo "City Name: $CITY"
 	echo "Map Center Latitude: $MAP_CENTER_LAT"
 	echo "Map Center Longitude: $MAP_CENTER_LONG"
-	echo "Time Difference between Server Timezone and UTC: $TIME_INTERVAL"
 	echo "GMaps API Key: $GMAPS_KEY"
 	echo "Server Timezone: $TIMEZONE"
 	echo
@@ -107,7 +104,6 @@ sed	-e "s/\"Worldopole\"/\"$SITE_NAME\"/" \
 	-e "s/\"Weuuurld\"/\"$CITY\"/" \
 	-e "s/\"50.844441\"/\"$MAP_CENTER_LAT\"/" \
 	-e "s/\"4.363557\"/\"$MAP_CENTER_LONG\"/" \
-	-e "s/\"+2\"/\"$TIME_INTERVAL\"/" \
 	-e "s/#GMAPS_KEY#/$GMAPS_KEY/" \
 	-e "s/\"Europe\/Paris\"/\"$TIMEZONE\"/" \
 "$VARIABLES_JSON_EX" > "$VARIABLES_JSON"


### PR DESCRIPTION
## Description
- no need to set an offset anymore --> no DST issues anymore
- support for timezones with hour **and** minute offset
- faster SQL queries
- less code :)
- Replace NOW() + INTERVAL with UTC_TIMESTAMP()
  - All time columns are in MySQL datetime format, so they are UTC only
We don't have to worry about timezones in those SQL statements
- update config and install.sh

Please review and test 👍 

## Motivation and Context
Wanted to implement #132 and hit performance issues with timezone conversion in SQL.
After having a deeper look at it I found the issue but decided it would be cool to improve the time zone support beforehand xD

## How Has This Been Tested?
locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)