### PR TITLE
Show the newest scanned instead longest live Pokémon as Recents

### DIFF
--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -148,12 +148,12 @@ switch ($request) {
 			}
 
 			// get last mythic pokemon
-			$req		= "SELECT pokemon_id FROM pokemon
+			$req		= "SELECT pokemon_id FROM pokemon, last_modified
 					   WHERE pokemon_id IN (".implode(",", $mythic_pokemons).")
 					   ORDER BY last_modified DESC LIMIT 0,1";
 		} else {
 			// get last pokemon
-			$req		= "SELECT pokemon_id FROM pokemon ORDER BY last_modified DESC LIMIT 0,1";
+			$req		= "SELECT pokemon_id FROM pokemon, last_modified ORDER BY last_modified DESC LIMIT 0,1";
 		}
 		$result 	= $mysqli->query($req);
 		$recents	= array();

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -150,10 +150,10 @@ switch ($request) {
 			// get last mythic pokemon
 			$req		= "SELECT pokemon_id FROM pokemon
 					   WHERE pokemon_id IN (".implode(",", $mythic_pokemons).")
-					   ORDER BY disappear_time DESC LIMIT 0,1";
+					   ORDER BY last_modified DESC LIMIT 0,1";
 		} else {
 			// get last pokemon
-			$req		= "SELECT pokemon_id FROM pokemon ORDER BY disappear_time DESC LIMIT 0,1";
+			$req		= "SELECT pokemon_id FROM pokemon ORDER BY last_modified DESC LIMIT 0,1";
 		}
 		$result 	= $mysqli->query($req);
 		$recents	= array();

--- a/core/process/data.loader.php
+++ b/core/process/data.loader.php
@@ -424,12 +424,12 @@ else {
 		}
 	
 		// get all mythic pokemon
-		$req 		= "SELECT DISTINCT pokemon_id, disappear_time FROM pokemon
+		$req 		= "SELECT DISTINCT pokemon_id, disappear_time, last_modified FROM pokemon
 				   WHERE pokemon_id IN (".implode(",", $mythic_pokemons).")
 				   ORDER BY last_modified DESC LIMIT 0,12";
 	} else {
 		// get all pokemon
-		$req		= "SELECT DISTINCT pokemon_id, disappear_time FROM pokemon ORDER BY last_modified DESC LIMIT 0,12";
+		$req		= "SELECT DISTINCT pokemon_id, disappear_time, last_modified FROM pokemon ORDER BY last_modified DESC LIMIT 0,12";
 	}
 	$result 	= $mysqli->query($req);
 	$recents	= array();

--- a/core/process/data.loader.php
+++ b/core/process/data.loader.php
@@ -426,10 +426,10 @@ else {
 		// get all mythic pokemon
 		$req 		= "SELECT DISTINCT pokemon_id, disappear_time FROM pokemon
 				   WHERE pokemon_id IN (".implode(",", $mythic_pokemons).")
-				   ORDER BY disappear_time DESC LIMIT 0,12";
+				   ORDER BY last_modified DESC LIMIT 0,12";
 	} else {
 		// get all pokemon
-		$req		= "SELECT DISTINCT pokemon_id, disappear_time FROM pokemon ORDER BY disappear_time DESC LIMIT 0,12";
+		$req		= "SELECT DISTINCT pokemon_id, disappear_time FROM pokemon ORDER BY last_modified DESC LIMIT 0,12";
 	}
 	$result 	= $mysqli->query($req);
 	$recents	= array();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The PR changes the most recents to show the newest scanned Pokémon by using the last_modified instead of disappear_time information of the DB.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR focuses the issue #123, that the most recent list is not showing the real most recent Pokémon but those who are live for the longest time into the future. This resulted, especially for the mythic recents, into a list of 59 minute Mythics instead of new information when e. g. a new Dragonite is scanned but is only a 30 min spawn and therefore not shown in the most recent list. Also there will be more dynamic in the most recents with this change.

We have to be careful with hex-scanning Maps which over-scan some Pokémon, as well as -ss cluster spawns which also might be overscanned. If someone has an even better solution that also addresses this issue, please contribute :-)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
