### PR TITLE
Fix date slider for Safari

### DIFF
--- a/core/js/pokemon.maps.js
+++ b/core/js/pokemon.maps.js
@@ -116,16 +116,19 @@ function initSlider(){
 			'type' : 'pokemon_slider_init'
 		}
 	}).done(function(bounds){
-		var selectorMax = new Date(bounds.max);
-		var selectorMin = new Date(bounds.min);
+		var boundMin = new Date(bounds.min.replace(/-/g, "/"));
+		var boundMax = new Date(bounds.max.replace(/-/g, "/"));
+		var selectorMax = boundMax;
+		var selectorMin = boundMin;
+		
 		var maxMinus2Weeks = new Date(selectorMax.getTime() - 2 * 7 * 24 * 60 * 60 * 1000);
 		if(selectorMin < maxMinus2Weeks){
 			selectorMin = maxMinus2Weeks;
 		}
 		$("#timeSelector").dateRangeSlider({
 			bounds:{
-				min: new Date(bounds.min),
-				max: new Date(bounds.max)
+				min: boundMin,
+				max: boundMax
 			},
 			defaultValues:{
 				min: selectorMin,

--- a/core/js/trainer.content.js
+++ b/core/js/trainer.content.js
@@ -7,13 +7,13 @@ $(function () {
 		var teamSelector=0; //0=all;1=Blue;2=Red;3=Yellow
 		var rankingFilter=0; //0=Level & Gyms; 1=Level; 2=Gyms
 
-		loadTrainers(page);
+		loadTrainers(page,null,null,null,pokeimg_suffix);
 		page++;
 		var win = $(window);
 		win.scroll(function () {
 			// End of the document reached?
 			if ($(document).height() - win.height() == win.scrollTop()) {
-				loadTrainers(page,$('input#name').val(),teamSelector,rankingFilter);
+				loadTrainers(page,$('input#name').val(),teamSelector,rankingFilter,pokeimg_suffix);
 				page++;
 			}
 		});
@@ -21,7 +21,7 @@ $(function () {
 			page = 0;
 			$('input#name').val()!=''?$('#trainersGraph').hide():$('#trainersGraph').show();
 			$('#trainersContainer tr:not(.trainersTemplate)').remove();
-			loadTrainers(page,$('input#name').val(),teamSelector,rankingFilter);
+			loadTrainers(page,$('input#name').val(),teamSelector,rankingFilter,pokeimg_suffix);
 			page++;
 			event.preventDefault();
 		});
@@ -67,79 +67,122 @@ $(function () {
 			
 		});
 
-		function loadTrainers(page,name,teamSelector,rankingFilter)
-		{
-			$('.trainerLoader').show();
-			
-			var trainerIndex = 0+(page*10);
-			$.ajax({
-				'async': true,
-				'type': "GET",
-				'global': false,
-				'dataType': 'json',
-				'url': "core/process/aru.php",
-				'data': {
-					'request': "",
-					'target': 'arrange_url',
-					'method': 'method_target',
-					'type' : 'trainer',
-					'page' : page,
-					'name' : name,
-					'team' : teamSelector,
-					'ranking' :rankingFilter
-				}
-			}).done(function (data) {
-				$.each(data, function (trainerName, trainer) {
-					trainerIndex++;
-					
-					var trainersInfos = $('<tr>',{id: 'trainerInfos_'+trainer.name}).css('border-bottom','2px solid '+(trainer.team=="3"?"#ffbe08":trainer.team=="2"?"#ff7676":"#00aaff"));
-					trainersInfos.append($('<td>',{id : 'trainerIndex_'+trainer.name, text : trainerIndex}));
-					trainersInfos.append($('<td>',{id : 'trainerRank_'+trainer.name, text : trainer.rank}));
-					trainersInfos.append($('<td>',{id : 'trainerName_'+trainer.name, text : trainerName}).click(
-						function (e) {
-							e.preventDefault();$('input#name').val(trainerName);
-							$("#searchTrainer").submit();
-							$('#trainerName_'+trainer.name).off('click');
-						}
-					));
-					trainersInfos.append($('<td>',{id : 'trainerLevel_'+trainer.name, text : trainer.level}));
-					trainersInfos.append($('<td>',{id : 'trainerGyms_'+trainer.name, text : trainer.gyms}));
-					trainersInfos.append($('<td>',{id : 'trainerLastSeen_'+trainer.name, text : trainer.last_seen}));
-					$('#trainersContainer').append(trainersInfos);
-					var trainersPokemonsRow = $('<tr>',{id: 'trainerPokemons_'+trainer.name});
-					var trainersPokemons = $('<td>',{colspan : 6});
-					var trainersPokemonsContainer = $('<div>',{class : ""});
-					for (var pokeIndex = 0; pokeIndex<trainer.pokemons.length; pokeIndex++) {
-						var pokemon = trainer.pokemons[pokeIndex];
-						var trainerPokemon = $('<div>',{id : 'trainerPokemon_'+pokemon.pokemon_uid, class: "col-md-1 col-xs-4 pokemon-single", style: "text-align: center" });
-						trainerPokemon.append($('<a>',{href : 'pokemon/'+pokemon.pokemon_id}).append($('<img />',{src : 'core/pokemons/'+pokemon.pokemon_id+pokeimg_suffix, 'class' : 'img-responsive '+(pokemon.gym_id===null?"unseen":"")})));
-						trainerPokemon.append($('<p>',{class : 'pkmn-name'}).append(pokemon.cp));
-						var progressBar = $('<div>',{class : 'progress'}).css({'height': '6px','margin-bottom': '0'});
-						progressBar.append($('<div>',{title: 'IV Stamina :'+pokemon.iv_stamina, class: 'progress-bar progress-bar-success' ,role : 'progressbar', 'aria-valuenow' :pokemon.iv_stamina, 'aria-valuemin' : 0, 'aria-valuemax' : 45}).css('width',((100/45)*pokemon.iv_stamina ) + '%'))
-						progressBar.append($('<div>',{title: 'IV Attack :'+pokemon.iv_attack, class: 'progress-bar progress-bar-danger' ,role : 'progressbar', 'aria-valuenow' : pokemon.iv_attack, 'ria-valuemin' : 0, 'aria-valuemax' : 45}).css('width',((100/45)*pokemon.iv_attack ) + '%'))
-						progressBar.append($('<div>',{title: 'IV Defense :'+pokemon.iv_defense, class: 'progress-bar progress-bar-info' ,role : 'progressbar', 'aria-valuenow': pokemon.iv_defense, 'aria-valuemin' : 0, 'aria-valuemax' : 45}).css('width',((100/45)*pokemon.iv_defense ) + '%'))
-						trainerPokemon.append(progressBar);
-						if (pokemon.last_scanned === '0') {
-							trainerPokemon.append($('<small>',{text: "Today"}));
-						}
-						else if (pokemon.last_scanned === '1') {
-							trainerPokemon.append($('<small>',{text: pokemon.last_scanned + " Day"}));
-						}
-						else {
-							trainerPokemon.append($('<small>',{text: pokemon.last_scanned + " Days"}));
-						}
-						trainersPokemonsContainer.append(trainerPokemon);
-					}
-					
-					trainersPokemons.append(trainersPokemonsContainer);
-					trainersPokemonsRow.append(trainersPokemons);
-					$('#trainersContainer').append(trainersPokemonsRow);
-					
-				});
-				
-				$('.trainerLoader').hide();
-			
-			});
-		};
-        });
+		
+	});
 });
+
+function loadTrainers(page,name,teamSelector,rankingFilter,pokeimg_suffix) {
+	$('.trainerLoader').show();
+	var trainerIndex = 0+(page*10);
+	$.ajax({
+		'async': true,
+		'type': "GET",
+		'global': false,
+		'dataType': 'json',
+		'url': "core/process/aru.php",
+		'data': {
+			'request': "",
+			'target': 'arrange_url',
+			'method': 'method_target',
+			'type' : 'trainer',
+			'page' : page,
+			'name' : name,
+			'team' : teamSelector,
+			'ranking' :rankingFilter
+		}
+	}).done(function (data) {
+		$.each(data, function (trainerName, trainer) {
+			trainerIndex++;
+			printTrainer(trainer, trainerIndex,pokeimg_suffix);
+		});
+		$('.trainerLoader').hide();
+	});
+};
+function printTrainer(trainer, trainerIndex,pokeimg_suffix) {
+	var trainersInfos = $('<tr>',{id: 'trainerInfos_'+trainer.name}).css('border-bottom','2px solid '+(trainer.team=="3"?"#ffbe08":trainer.team=="2"?"#ff7676":"#00aaff"));
+	trainersInfos.append($('<td>',{id : 'trainerIndex_'+trainer.name, text : trainerIndex}));
+	trainersInfos.append($('<td>',{id : 'trainerRank_'+trainer.name, text : trainer.rank}));
+	trainersInfos.append($('<td>',{id : 'trainerName_'+trainer.name, text : trainer.name}).click(
+		function (e) {
+			e.preventDefault();$('input#name').val(trainer.name);
+			$("#searchTrainer").submit();
+			$('#trainerName_'+trainer.name).off('click');
+		}
+	));
+	trainersInfos.append($('<td>',{id : 'trainerLevel_'+trainer.name, text : trainer.level}));
+	trainersInfos.append($('<td>',{id : 'trainerGyms_'+trainer.name, text : trainer.gyms}));
+	trainersInfos.append($('<td>',{id : 'trainerLastSeen_'+trainer.name, text : trainer.last_seen}));
+	$('#trainersContainer').append(trainersInfos);
+	var trainersPokemonsRow = $('<tr>',{id: 'trainerPokemons_'+trainer.name});
+	var trainersPokemons = $('<td>',{colspan : 6});
+	var trainersPokemonsContainer = $('<div>',{class : ""});
+	for (var pokeIndex = 0; pokeIndex<trainer.pokemons.length; pokeIndex++) {
+		var pokemon = trainer.pokemons[pokeIndex];
+		
+		trainersPokemonsContainer.append(printPokemon(pokemon,pokeimg_suffix));
+	}
+
+	trainersPokemons.append(trainersPokemonsContainer);
+	trainersPokemonsRow.append(trainersPokemons);
+	$('#trainersContainer').append(trainersPokemonsRow);
+}
+
+function printPokemon(pokemon,pokeimg_suffix){
+	var trainerPokemon = $('<div>',{id : 'trainerPokemon_'+pokemon.pokemon_uid, class: "col-md-1 col-xs-4 pokemon-single", style: "text-align: center" });
+	var gymClass = "";
+	if ((pokemon.gym_id===null)) {
+		gymClass = "unseen";
+	}
+	trainerPokemon.append(
+		$('<a>',
+			{href : 'pokemon/'+pokemon.pokemon_id}
+		).append($('<img />',
+			{	src : 'core/pokemons/'+pokemon.pokemon_id+pokeimg_suffix,
+				'class' : 'img-responsive '+gymClass
+			})
+		)
+	);
+	trainerPokemon.append($('<p>',{class : 'pkmn-name'}).append(pokemon.cp));
+	var progressBar = $('<div>',{class : 'progress'}).css({'height': '6px','margin-bottom': '0'});
+	progressBar.append(
+		$('<div>',
+			{
+			title: 'IV Stamina :'+pokemon.iv_stamina, 
+			class: 'progress-bar progress-bar-success' ,
+			role : 'progressbar',
+			'aria-valuenow' :pokemon.iv_stamina,
+			'aria-valuemin' : 0, 
+			'aria-valuemax' : 45
+		}).css('width',((100/45)*pokemon.iv_stamina ) + '%'))
+	progressBar.append(
+		$('<div>',
+			{
+			title: 'IV Attack :'+pokemon.iv_attack, 
+			class: 'progress-bar progress-bar-danger' ,
+			role : 'progressbar', 
+			'aria-valuenow' : pokemon.iv_attack, 
+			'aria-valuemin' : 0, 
+			'aria-valuemax' : 45
+		}).css('width',((100/45)*pokemon.iv_attack ) + '%'))
+	progressBar.append(
+		$('<div>',
+			{
+			title: 'IV Defense :'+pokemon.iv_defense,
+			class: 'progress-bar progress-bar-info' ,
+			role : 'progressbar', 
+			'aria-valuenow': pokemon.iv_defense, 
+			'aria-valuemin' : 0, 
+			'aria-valuemax' : 45
+		}).css('width',((100/45)*pokemon.iv_defense ) + '%'))
+	trainerPokemon.append(progressBar);
+	if (pokemon.last_scanned === '0') {
+		trainerPokemon.append($('<small>',{text: "Today"}));
+	}
+	else if (pokemon.last_scanned === '1') {
+		trainerPokemon.append($('<small>',{text: pokemon.last_scanned + " Day"}));
+	}
+	else {
+		trainerPokemon.append($('<small>',{text: pokemon.last_scanned + " Days"}));
+	}
+	return trainerPokemon;
+}


### PR DESCRIPTION
## Description
Date parsing in Safari stick too much to ECMA guidelines so a trick is needed to use MYSQL date string with the javascript parser from safari...

## How Has This Been Tested?
Localhost lastest version of safari

## Screenshots (if appropriate):
![image](https://cloud.githubusercontent.com/assets/72618/22403297/2564e84c-e613-11e6-9898-a6824b3b24c3.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
