### PR TITLE
Fix stats files language issues when using foced_lang (Dashboard)

### DIFF
--- a/core/cron/crontabs.include.php
+++ b/core/cron/crontabs.include.php
@@ -8,6 +8,10 @@ $config_file	= $filePath.'/../../config.php';
 
 include_once($config_file);
 
+// Load variables.json
+$variables      = '/../json/variables.json';
+$config         = json_decode(file_get_contents($variables));
+
 // Manage Time Interval
 // #####################
 

--- a/core/cron/crontabs.include.php
+++ b/core/cron/crontabs.include.php
@@ -11,6 +11,8 @@ include_once($config_file);
 // Load variables.json
 $variables      = $filePath.'/../json/variables.json';
 $config         = json_decode(file_get_contents($variables));
+// force english language for all cron stuff
+$config->system->forced_lang = 'en';
 
 // Manage Time Interval
 // #####################

--- a/core/cron/crontabs.include.php
+++ b/core/cron/crontabs.include.php
@@ -9,7 +9,7 @@ $config_file	= $filePath.'/../../config.php';
 include_once($config_file);
 
 // Load variables.json
-$variables      = '/../json/variables.json';
+$variables      = $filePath.'/../json/variables.json';
 $config         = json_decode(file_get_contents($variables));
 
 // Manage Time Interval

--- a/core/cron/pokemon.cron.php
+++ b/core/cron/pokemon.cron.php
@@ -9,8 +9,7 @@
 // This file is used to rank by rarity 
 
 // Load the pokemons array
-// force english language
-$config->system->forced_lang = 'en';
+// crontabs.include.php forces english lang
 include_once($filePath.'/../process/locales.loader.php');
 
 

--- a/core/cron/pokemon.cron.php
+++ b/core/cron/pokemon.cron.php
@@ -9,9 +9,8 @@
 // This file is used to rank by rarity 
 
 // Load the pokemons array
-// will load english one because language is not set
-############################
-
+// force english language
+$config->system->forced_lang = 'en';
 include_once($filePath.'/../process/locales.loader.php');
 
 

--- a/core/js/dashboard.graph.js.php
+++ b/core/js/dashboard.graph.js.php
@@ -40,39 +40,37 @@ foreach ($stats as $data) {
 		$total[]		= $data->pokemon_now;
 	}
 	
-	if ($data->timestamp > $yesterday) {
-		$labels[] = '"'.date('H:i', $data->timestamp).'"';
+	if($data->timestamp > $yesterday){
+		
+		$labels[] = '"'.date('H:i', $data->timestamp ).'"'; 
+		
 
-		$veryCommonLocale = $locales->VERYCOMMON;
-		$commonLocale = $locales->COMMON;
-		$rareLocale = $locales->RARE;
-		$mythicLocale = $locales->MYTHIC;
-
-		if (!empty($data->rarity_spawn->$veryCommonLocale)) {
-			$veco[]		= $data->rarity_spawn->$veryCommonLocale;
-		} else {
-			$veco[]		= 0;
+		if(!empty($data->rarity_spawn->{'Very common'})){
+			$veco[]		= $data->rarity_spawn->{'Very common'};
+		}
+		else{
+			$veco[]		= 0; 
 		}
 		
 	
-		if (!empty($data->rarity_spawn->$commonLocale)) {
-			$commo[]	= $data->rarity_spawn->$commonLocale;
-		} else {
-			$commo[]	= 0;
+		if(!empty($data->rarity_spawn->Common)){
+			$commo[]	= $data->rarity_spawn->Common;
+		}
+		else{
+			$commo[]	= 0; 
 		}
 		
 	
-		if (!empty($data->rarity_spawn->$rareLocale)) {
-			$rare[]		= $data->rarity_spawn->$rareLocale;
-		} else {
-			$rare[]		= 0;
+		if(!empty($data->rarity_spawn->Mythic)){
+			$rare[]		= $data->rarity_spawn->Rare;
+		}
+		else{
+			$rare[]		= 0; 
 		}
 		
 	
-		if (!empty($data->rarity_spawn->$mythicLocale)) {
-			$myth[]		= $data->rarity_spawn->$mythicLocale;
-		} else {
-			$myth[]		= 0;
+		if(!empty($data->rarity_spawn->Mythic)){
+			$myth[]		= $data->rarity_spawn->Mythic;
 		}
 	}
 }

--- a/core/js/dashboard.graph.js.php
+++ b/core/js/dashboard.graph.js.php
@@ -61,7 +61,7 @@ foreach ($stats as $data) {
 		}
 		
 	
-		if(!empty($data->rarity_spawn->Mythic)){
+		if(!empty($data->rarity_spawn->Rare)){
 			$rare[]		= $data->rarity_spawn->Rare;
 		}
 		else{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The content of `pokemon.stats.json` was in (if set) `forced_lang` language which is really bad :-1: 
- This fix reverts #126 and fixes the issue for real: Force english for ALL cronjobs
- On top of that it fixes a $config not defined error

You might need to fix your existing `core/json/pokemon.stats.json` file.
Do a backup of this file before you execute the following.

For german:
```bash
sed -i -e 's/"Sehr selten"/"Mythic"/g' -e 's/"Selten"/"Rare"/g' -e 's/"H\\u00e4ufig"/"Common"/g' -e 's/"Sehr h\\u00e4ufig"/"Very common"/g' -e 's/"nicht gesehen"/"unseen"/g' core/json/pokemon.stats.json
```
For other languages just replace the translation strings.

## How Has This Been Tested?
discord

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)