### PR TITLE
Fix slidertext on mobile device

### DIFF
--- a/core/js/pokemon.maps.js
+++ b/core/js/pokemon.maps.js
@@ -1,5 +1,6 @@
 /** global: google */
 /** global: pokemon_id */
+/** global: navigator */
 var map, heatmap;
 var pokemonMarkers = [];
 var updateLiveTimeout;

--- a/core/js/pokemon.maps.js
+++ b/core/js/pokemon.maps.js
@@ -164,7 +164,13 @@ function initHeatmapData(bounds){
 				return next;
 			},
 			label: function(value){
-				return "Migration #" + migrations[value.getTime()];
+				if (isMobileDevice() && isTouchDevice()) {
+					return "#" + migrations[value.getTime()];
+				}
+				else {
+					return "Migration #" + migrations[value.getTime()];
+				}
+				
 			},
 		}]
 	});
@@ -404,4 +410,14 @@ function extractEncountersId(){
 	}
 	
 	return inmapEncounter;
+}
+
+function isTouchDevice() {
+    // Should cover most browsers
+    return 'ontouchstart' in window || navigator.maxTouchPoints
+}
+
+function isMobileDevice() {
+    //  Basic mobile OS (not browser) detection
+    return (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent))
 }


### PR DESCRIPTION
## Description
- Write only "#Number" into the slidebar on mobile
- "Migration #Number" was too long on mobile

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
