### PR TITLE
Option to only show lured Pokestops on map

### DIFF
--- a/core/json/variables.examples.json
+++ b/core/json/variables.examples.json
@@ -29,6 +29,7 @@
 		"recents_filter"	:	true,
 		"recents_filter_rating"	:	8,
 		"recents_filter_rarity"	:	0.01,
+		"only_lured_pokestops" : false,
 		"captcha_support"	:	false,
 		"iv_numbers"		:	false,
 		"forced_lang"		:	""
@@ -70,6 +71,6 @@
 			"text"		:	"Twitter",
 			"icon"		:	"fa-twitter"
 		}
-		
+
 	]
 }

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -284,7 +284,7 @@ switch ($request) {
 			if ($data->lure_expiration >= $data->now) {
 				$icon = 'pokestap_lured.png';
 				$text = 'Lured expire @ '.date('H:i:s', strtotime($data->lure_expiration_real)) ;
-			} else {
+			} elseif (!($config->system->only_lured_pokestops)) {
 				$icon = 'pokestap.png';
 				$text = 'Normal stop';
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add feature request by user via Discord. This PR tries to only show lured Pokéstops on /pokestop map, when variables.json flag is set to ``true``. Let's see. Read code. Maybe I am just bad.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

CLOSING BECAUSE BUG.
Redirect to #203