### PR TITLE
Only show lured stops on /pokestop map

### DIFF
--- a/core/json/variables.examples.json
+++ b/core/json/variables.examples.json
@@ -1,4 +1,4 @@
-{
+﻿{
 	"urls":{
 		"fb_valor"		:	"http://bit.ly/ValorBrussels",
 		"fb_mystic"		:	"http://bit.ly/MysticBrussels",
@@ -29,6 +29,7 @@
 		"recents_filter"	:	true,
 		"recents_filter_rating"	:	8,
 		"recents_filter_rarity"	:	0.01,
+		"only_lured_pokestops"  :	false,
 		"captcha_support"	:	false,
 		"iv_numbers"		:	false,
 		"forced_lang"		:	""

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -275,7 +275,11 @@ switch ($request) {
 	####################################
 
 	case 'pokestop':
-		$req 		= "SELECT latitude, longitude, lure_expiration, UTC_TIMESTAMP() as now, (CONVERT_TZ(lure_expiration, '+00:00', '".$time_offset."')) as lure_expiration_real FROM pokestop";
+		if (!($config->system->only_lured_pokestops)) {
+			$req 		= "SELECT latitude, longitude, lure_expiration, UTC_TIMESTAMP() as now, (CONVERT_TZ(lure_expiration, '+00:00', '".$time_offset."')) as lure_expiration_real FROM pokestop";
+		} else {
+			$req 		= "SELECT latitude, longitude, lure_expiration, UTC_TIMESTAMP() as now, (CONVERT_TZ(lure_expiration, '+00:00', '".$time_offset."')) as lure_expiration_real FROM pokestop WHERE lure_expiration > UTC_TIMESTAMP()";
+		}
 		$result 	= $mysqli->query($req);
 
 		$i=0;


### PR DESCRIPTION
## Description
This PR adds the feature to only show lured Pokéstops on /pokestop
map, when variables.json flag is set to `true`.

## Motivation and Context
This is an easy option to be able to customise the map on the /pokemon page.

## How Has This Been Tested?
This has been tested on a public page, and shown to "z0n" & "Arengo"

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
