### PR TITLE
Improve accept language handling

### DIFF
--- a/core/json/variables.examples.json
+++ b/core/json/variables.examples.json
@@ -33,8 +33,9 @@
 		"only_lured_pokestops"  :	false,
 		"captcha_support"		:	false,
 		"iv_numbers"			:	false,
-		"forced_lang"			:	""
-	},
+		"forced_lang"			:	"",
+		"default_lang"			:	"en"
+	},	
 	"menu":[
 		{
 			"type"		:	"link",

--- a/core/process/locales.loader.php
+++ b/core/process/locales.loader.php
@@ -19,8 +19,7 @@
  *
  * @return array Sorted list of "accept" options
  */
-$sortAccept = function($header)
-{
+$sortAccept = function ($header) {
 	$matches = array();
 	foreach (explode(',', $header) as $option) {
 		$option = array_map('trim', explode(';', $option));
@@ -53,8 +52,7 @@ $sortAccept = function($header)
  *
  * @return string|NULL a matched option, or NULL if no match
  */
-$matchAccept = function($header, $supported) use ($sortAccept)
-{
+$matchAccept = function ($header, $supported) use ($sortAccept) {
 	$matches = $sortAccept($header);
 	foreach ($matches as $key => $q) {
 		if (isset($supported[$key])) {
@@ -85,8 +83,7 @@ $matchAccept = function($header, $supported) use ($sortAccept)
  *
  * @return string The negotiated language result or the supplied default.
  */
-$negotiateLanguage = function($supported, $default = 'en-US') use ($matchAccept)
-{
+$negotiateLanguage = function ($supported, $default = 'en-US') use ($matchAccept) {
 	$supp = array();
 	foreach ($supported as $lang => $isSupported) {
 		if ($isSupported) {

--- a/core/process/locales.loader.php
+++ b/core/process/locales.loader.php
@@ -162,27 +162,27 @@ unset($pokemon_trans_array);
 // Merge the pokedex, pokemon translation and rarity file into a new array 
 ##########################################################################
 
-$pokedex_file = file_get_contents(SYS_PATH.'/core/json/pokedex.json');
-$pokemons = json_decode($pokedex_file);
+$pokedex_file 	= file_get_contents(SYS_PATH.'/core/json/pokedex.json');
+$pokemons 		= json_decode($pokedex_file);
 
 $pokedex_rarity_file = SYS_PATH.'/core/json/pokedex.rarity.json';
 // initial create of pokedex.rarity.json if it doesn't exist
 if (!is_file($pokedex_rarity_file)) {
 	include_once(SYS_PATH.'/core/cron/pokedex.rarity.php');
 }
-$pokedex_rarity_file_content = file_get_contents($pokedex_rarity_file);
-$pokemons_rarity = json_decode($pokedex_rarity_file_content);
+$pokedex_rarity_file_content 	= file_get_contents($pokedex_rarity_file);
+$pokemons_rarity 				= json_decode($pokedex_rarity_file_content);
 
 foreach ($pokemons->pokemon as $pokeid => $pokemon) {
 	// Merge name and description from translation files
-	$pokemon->name = $pokemon_trans->pokemon->$pokeid->name;
-	$pokemon->description = $pokemon_trans->pokemon->$pokeid->description;
+	$pokemon->name 			= $pokemon_trans->pokemon->$pokeid->name;
+	$pokemon->description 	= $pokemon_trans->pokemon->$pokeid->description;
 
 	// Replace quick and charge move with translation
-	$quick_move = $pokemon->quick_move;
-	$pokemon->quick_move = $pokemon_trans->quick_moves->$quick_move;
-	$charge_move = $pokemon->charge_move;
-	$pokemon->charge_move = $pokemon_trans->charge_moves->$charge_move;
+	$quick_move 			= $pokemon->quick_move;
+	$pokemon->quick_move 	= $pokemon_trans->quick_moves->$quick_move;
+	$charge_move 			= $pokemon->charge_move;
+	$pokemon->charge_move 	= $pokemon_trans->charge_moves->$charge_move;
 
 	// Replace types with translation
 	foreach ($pokemon->types as &$type) {
@@ -192,8 +192,8 @@ foreach ($pokemons->pokemon as $pokeid => $pokemon) {
 
 	// Resolve candy_id to candy_name
 	if (isset($pokemon->candy_id)) {
-		$candy_id = $pokemon->candy_id;
-		$pokemon->candy_name = $pokemon_trans->pokemon->$candy_id->name;
+		$candy_id 				= $pokemon->candy_id;
+		$pokemon->candy_name 	= $pokemon_trans->pokemon->$candy_id->name;
 		unset($pokemon->candy_id);
 	}
 	// Convert move numbers to names
@@ -229,8 +229,8 @@ foreach ($pokemons->pokemon as $pokeid => $pokemon) {
 // Translate typecolors array keys as well
 $types_temp = new stdClass();
 foreach ($pokemons->typecolors as $type => $color) {
-	$type_trans = $pokemon_trans->types->$type;
-	$types_temp->$type_trans = $color;
+	$type_trans 				= $pokemon_trans->types->$type;
+	$types_temp->$type_trans 	= $color;
 }
 // Replace typecolors array with translated one
 $pokemons->typecolors = $types_temp;

--- a/core/process/locales.loader.php
+++ b/core/process/locales.loader.php
@@ -1,56 +1,148 @@
 <?php
 
+/**
+ * The next 3 functions come from the HTTP2 pear package 
+ * Copyright (c) 2002-2005, 
+ * Stig Bakken <ssb@fast.no>,
+ * Sterling Hughes <sterling@php.net>,
+ * Tomas V.V.Cox <cox@idecnet.com>,
+ * Richard Heyes <richard@php.net>,
+ * Philippe Jausions <Philippe.Jausions@11abacus.com>,
+ * Michael Wallner <mike@php.net>.
+ * Licensed under http://www.opensource.org/licenses/bsd-license.php  New BSD License
+ */
+
+/**
+ * Negotiates language with the user's browser through the Accept-Language
+ * HTTP header or the user's host address.  Language codes are generally in
+ * the form "ll" for a language spoken in only one country, or "ll-CC" for a
+ * language spoken in a particular country.  For example, U.S. English is
+ * "en-US", while British English is "en-UK".  Portugese as spoken in
+ * Portugal is "pt-PT", while Brazilian Portugese is "pt-BR".
+ *
+ * Quality factors in the Accept-Language: header are supported, e.g.:
+ *      Accept-Language: en-UK;q=0.7, en-US;q=0.6, no, dk;q=0.8
+ *
+ * @param array  $supported An associative array of supported languages,
+ *                          whose values must evaluate to true.
+ * @param string $default   The default language to use if none is found.
+ *
+ * @return string The negotiated language result or the supplied default.
+ */
+function negotiateLanguage($supported, $default = 'en-US')
+{
+	$supp = array();
+	foreach ($supported as $lang => $isSupported) {
+		if ($isSupported) {
+			$supp[strtolower($lang)] = $lang;
+		}
+	}
+	if (!count($supp)) {
+		return $default;
+	}
+	if (isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
+		$match = matchAccept(
+			$_SERVER['HTTP_ACCEPT_LANGUAGE'],
+			$supp
+		);
+		if (!is_null($match)) {
+			return $match;
+		}
+	}
+	if (isset($_SERVER['REMOTE_HOST'])) {
+		$lang = strtolower(end($h = explode('.', $_SERVER['REMOTE_HOST'])));
+		if (isset($supp[$lang])) {
+			return $supp[$lang];
+		}
+	}
+	return $default;
+}
+
+/**
+ * Parses a weighed "Accept" HTTP header and matches it against a list
+ * of supported options
+ *
+ * @param string $header    The HTTP "Accept" header to parse
+ * @param array  $supported A list of supported values
+ *
+ * @return string|NULL a matched option, or NULL if no match
+ */
+function matchAccept($header, $supported)
+{
+	$matches = sortAccept($header);
+	foreach ($matches as $key => $q) {
+		if (isset($supported[$key])) {
+			return $supported[$key];
+		}
+	}
+	// If any (i.e. "*") is acceptable, return the first supported format
+	if (isset($matches['*'])) {
+		return array_shift($supported);
+	}
+	return null;
+}
+
+/**
+ * Parses and sorts a weighed "Accept" HTTP header
+ *
+ * @param string $header The HTTP "Accept" header to parse
+ *
+ * @return array Sorted list of "accept" options
+ */
+function sortAccept($header)
+{
+	$matches = array();
+	foreach (explode(',', $header) as $option) {
+		$option = array_map('trim', explode(';', $option));
+		$l = strtolower($option[0]);
+		if (isset($option[1])) {
+			$q = (float) str_replace('q=', '', $option[1]);
+		} else {
+			$q = null;
+			// Assign default low weight for generic values
+			if ($l == '*/*') {
+				$q = 0.01;
+			} elseif (substr($l, -1) == '*') {
+				$q = 0.02;
+			}
+		}
+		// Unweighted values, get high weight by their position in the
+		// list
+		$matches[$l] = isset($q) ? $q : 1000 - count($matches);
+	}
+	arsort($matches, SORT_NUMERIC);
+	return $matches;
+}
 
 // Language setting
 ###################
 
 if (empty($config->system->forced_lang)) {
-	if (isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
-		$browser_lang = substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2);
-	} else {
-		$browser_lang = 'en';
-	}
+	$directories = glob(SYS_PATH.'/core/json/locales/*' , GLOB_ONLYDIR);
+	$directories = array_map("basename", $directories);
+	//print_r($directories);
+	$browser_lang = negotiateLanguage(array_fill_keys($directories, true), $config->system->default_lang);
+	//print_r($browser_lang);
 } else {
 	// Use forced language
 	$browser_lang = $config->system->forced_lang;
 }
 
 // Activate lang
-$lang = strtoupper($browser_lang);
-
-// Check if language is available
-if (isset($lang)) {
-	$locale_dir = SYS_PATH.'/core/json/locales/'.$lang;
-	
-	// If there's no pokedex in languague we'll use the english one.
-	if (is_dir($locale_dir)) {
-		// Allow partial translations
-		if (is_file($locale_dir.'/pokes.json')) {
-			$pokemon_file		= file_get_contents($locale_dir.'/pokes.json');
-		} else {
-			$pokemon_file		= file_get_contents(SYS_PATH.'/core/json/locales/EN/pokes.json');
-		}
-		
-		if (is_file($locale_dir.'/translations.json')) {
-			$translation_file	= file_get_contents($locale_dir.'/translations.json');
-		} else {
-			$translation_file	= file_get_contents(SYS_PATH.'/core/json/locales/EN/translations.json');
-		}
-		
-		if (is_file($locale_dir.'/moves.json')) {
-			$moves_file			= json_decode(file_get_contents($locale_dir.'/moves.json'));
-		} else {
-			$moves_file			= json_decode(file_get_contents(SYS_PATH.'/core/json/locales/EN/moves.json'));
-		}
-	} else {
-		$pokemon_file 			= file_get_contents(SYS_PATH.'/core/json/locales/EN/pokes.json');
-		$translation_file 		= file_get_contents(SYS_PATH.'/core/json/locales/EN/translations.json');
-		$moves_file				= json_decode(file_get_contents(SYS_PATH.'/core/json/locales/EN/moves.json'));
-	}
+$locale_dir = SYS_PATH.'/core/json/locales/'.strtoupper($browser_lang);
+// Allow partial translations
+$translation_file = "{}";
+$pokemon_file = "{}";
+if (is_file($locale_dir.'/pokes.json')) {
+	$pokemon_file		= file_get_contents($locale_dir.'/pokes.json');
+}
+if (is_file($locale_dir.'/translations.json')) {
+	$translation_file	= file_get_contents($locale_dir.'/translations.json');
+}
+if (is_file($locale_dir.'/moves.json')) {
+	$moves_file			= json_decode(file_get_contents($locale_dir.'/moves.json'));
 } else {
-	$pokemon_file			= file_get_contents(SYS_PATH.'/core/json/locales/EN/pokes.json');
-	$translation_file		= file_get_contents(SYS_PATH.'/core/json/locales/EN/translations.json');
-	$moves_file				= json_decode(file_get_contents(SYS_PATH.'/core/json/locales/EN/moves.json'));
+	$moves_file			= json_decode(file_get_contents(SYS_PATH.'/core/json/locales/EN/moves.json'));
 }
 
 
@@ -147,8 +239,8 @@ foreach ($pokemons->typecolors as $type => $color) {
 $pokemons->typecolors = $types_temp;
 
 // unset unused variables to prevent issues with other php scripts
+unset($directories);
 unset($browser_lang);
-unset($lang);
 unset($locale_dir);
 unset($pokemon_file);
 unset($translation_file);

--- a/core/process/locales.loader.php
+++ b/core/process/locales.loader.php
@@ -12,7 +12,7 @@
  * Licensed under http://www.opensource.org/licenses/bsd-license.php  New BSD License
  */
 
- /**
+/**
  * Parses and sorts a weighed "Accept" HTTP header
  *
  * @param string $header The HTTP "Accept" header to parse


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->
Improved accept language handling by parsing the full header and the q values.
It now uses the highest available language in the header.
Also cleaned include handling as there is no need for that much code.
I left forced_language even I am not sure if it is so usefull after this.

The only situation not being handled is when browser does sets a contry specific version and do not flag the generic one. For example `pt-BR, de` will return `de` instead of `pt`.

I did use the code from the HTTP2 library with full attributions.  

This fixes 3 situations:

 * It was impossible to handle country specific locales, now it is as easy as creating a folder with the correct name (like PT-BR).
 * While in most cases the browsers will return the language with the higher priority first this is not required by the standards.
 * Users could choose a second language over english and now it was first or nothing a browser using `cn, de` was seeing a english page.

Also there is now the possibility to define a default language other than english without forcing it, it no language is matched then the default is used.
Still english is used to fill the gaps in the locales as it is expected to be always up to date.

Just fast tests in my instance, did check all the situations I could think of.


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)