### PR TITLE
[Feature] Added support working behind a reverse https proxy

### DIFF
--- a/config.example.php
+++ b/config.example.php
@@ -37,18 +37,18 @@ if (directory() != '') {
 }
 
 if (isset($_SERVER['HTTP_HOST'])) {
-    if (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
-        define('HOST_URL', $_SERVER['HTTP_X_FORWARDED_PROTO'] . '://'.$_SERVER['HTTP_HOST'].$subdirectory);
-    }
-    else if (isset($_SERVER['REQUEST_SCHEME'])) {
-        define('HOST_URL', $_SERVER['REQUEST_SCHEME'].'://'.$_SERVER['HTTP_HOST'].$subdirectory);
-    } else {
-        if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') {
-            define('HOST_URL', 'https://'.$_SERVER['HTTP_HOST'].$subdirectory);
-        } else {
-            define('HOST_URL', 'http://'.$_SERVER['HTTP_HOST'].$subdirectory);
-        }
-    }
+	if (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
+		define('HOST_URL', $_SERVER['HTTP_X_FORWARDED_PROTO'] . '://'.$_SERVER['HTTP_HOST'].$subdirectory);
+	}
+	else if (isset($_SERVER['REQUEST_SCHEME'])) {
+		define('HOST_URL', $_SERVER['REQUEST_SCHEME'].'://'.$_SERVER['HTTP_HOST'].$subdirectory);
+	} else {
+		if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') {
+			define('HOST_URL', 'https://'.$_SERVER['HTTP_HOST'].$subdirectory);
+		} else {
+			define('HOST_URL', 'http://'.$_SERVER['HTTP_HOST'].$subdirectory);
+		}
+	}
 }
 
 ## Subdirectory trick
@@ -60,8 +60,8 @@ function directory()
 	if ($root == $filePath) {
 		return ''; // installed in the root
 	} else {
-		$subdir_path	= explode('/', $filePath);
-		$subdir		= end($subdir_path);
+		$subdir_path = explode('/', $filePath);
+		$subdir = end($subdir_path);
 		return $subdir;
 	}
 }

--- a/config.example.php
+++ b/config.example.php
@@ -6,7 +6,7 @@
  */
 
 
-# EDIT ME PLEASE 
+# EDIT ME PLEASE
 
 // mysql db name
 define('SYS_DB_NAME', '#SYS_DB_NAME#');
@@ -20,7 +20,7 @@ define('SYS_DB_HOST', '#SYS_DB_HOST#');
 define('SYS_DB_PORT', 3306);
 
 
-# Please, do not touch me, I'm fine ;) 
+# Please, do not touch me, I'm fine ;)
 
 // full path
 define('SYS_PATH', realpath(dirname(__FILE__)));
@@ -37,18 +37,21 @@ if (directory() != '') {
 }
 
 if (isset($_SERVER['HTTP_HOST'])) {
-	if (isset($_SERVER['REQUEST_SCHEME'])) {
-		define('HOST_URL', $_SERVER['REQUEST_SCHEME'].'://'.$_SERVER['HTTP_HOST'].$subdirectory);
-	} else {
-		if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') {
-			define('HOST_URL', 'https://'.$_SERVER['HTTP_HOST'].$subdirectory);
-		} else {
-			define('HOST_URL', 'http://'.$_SERVER['HTTP_HOST'].$subdirectory);
-		}
-	}
+    if(isset($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
+        define('HOST_URL', $_SERVER['HTTP_X_FORWARDED_PROTO'] . '://'.$_SERVER['HTTP_HOST'].$subdirectory);
+    }
+    else if (isset($_SERVER['REQUEST_SCHEME'])) {
+        define('HOST_URL', $_SERVER['REQUEST_SCHEME'].'://'.$_SERVER['HTTP_HOST'].$subdirectory);
+    } else {
+        if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') {
+            define('HOST_URL', 'https://'.$_SERVER['HTTP_HOST'].$subdirectory);
+        } else {
+            define('HOST_URL', 'http://'.$_SERVER['HTTP_HOST'].$subdirectory);
+        }
+    }
 }
 
-## Subdirectory trick 
+## Subdirectory trick
 function directory()
 {
 	$root = $_SERVER['DOCUMENT_ROOT'];

--- a/config.example.php
+++ b/config.example.php
@@ -37,7 +37,7 @@ if (directory() != '') {
 }
 
 if (isset($_SERVER['HTTP_HOST'])) {
-    if(isset($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
+    if (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
         define('HOST_URL', $_SERVER['HTTP_X_FORWARDED_PROTO'] . '://'.$_SERVER['HTTP_HOST'].$subdirectory);
     }
     else if (isset($_SERVER['REQUEST_SCHEME'])) {

--- a/config.example.php
+++ b/config.example.php
@@ -39,8 +39,7 @@ if (directory() != '') {
 if (isset($_SERVER['HTTP_HOST'])) {
 	if (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
 		define('HOST_URL', $_SERVER['HTTP_X_FORWARDED_PROTO'] . '://'.$_SERVER['HTTP_HOST'].$subdirectory);
-	}
-	else if (isset($_SERVER['REQUEST_SCHEME'])) {
+	} else if (isset($_SERVER['REQUEST_SCHEME'])) {
 		define('HOST_URL', $_SERVER['REQUEST_SCHEME'].'://'.$_SERVER['HTTP_HOST'].$subdirectory);
 	} else {
 		if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR changes the `config.example.php` so it will work if you're doing a reverse proxy trough https

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
On setups like my own with a https reverse proxy worldpoley without this won't work.
Because some requests would be make trough http (insecure), https required pretty much all requests to be made trought https
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
