### PR TITLE
Remaining time (Homepage)

### DIFF
--- a/core/js/home.script.js
+++ b/core/js/home.script.js
@@ -115,6 +115,6 @@ function formatDuration(remainingTime)
 	minutes = minutes < 10 ? "0" + minutes : minutes;
 	seconds = seconds < 10 ? "0" + seconds: seconds;
 
-	var output = (countdown<0?"- ":"")+hours + ":" + minutes + ":" + seconds;
+	var output = countdown<0?"00:00:00":""+hours + ":" + minutes + ":" + seconds;
 	return output;
 }


### PR DESCRIPTION
the remaining time under the pokemon on the homepage at "the most recent/mythic spanws"
are now once expired 00:00:00 and no more -00:03:45.

example:
![timers](https://cloud.githubusercontent.com/assets/22316434/24848791/d9ab494e-1dc8-11e7-9f65-caac14ebba8a.jpg)
