### PR TITLE
Display Pokémon ID also in each Pokémon page

### DIFF
--- a/pages/pokemon.page.php
+++ b/pages/pokemon.page.php
@@ -27,7 +27,7 @@
 
 		<div class="col-sm-10 text-center">
 
-			<h1><strong><?= $pokemon->name ?></strong><br>
+			<h1>#<?= sprintf('%03d <strong>%s</strong>', $pokemon->id, $pokemon->name) ?><br>
 			<small>[<?= $pokemon->rarity ?>]</small></h1>
 
 			<p id="share">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Pokémon ID was missing in the pokemon.page.php until now. This PR wants to extend the Pokémon ID, displayed for each entry in the Pokédex, to each of it's dedicated pages.

## Screenshots:
<img width="313" alt="bildschirmfoto 2017-04-13 um 13 20 28" src="https://cloud.githubusercontent.com/assets/22680515/25002771/6fd93fcc-204c-11e7-85e7-a491b4186616.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Minor
