### PR TITLE
Fix live maps for instances/pokemon without encounter

### DIFF
--- a/core/js/pokemon.maps.js
+++ b/core/js/pokemon.maps.js
@@ -292,24 +292,31 @@ function addPokemonMarker(pokemon,pokeimg_suffix, locale) {
 		anchor: new google.maps.Point(16, 16),
 		labelOrigin : new google.maps.Point(16, 36)
 	};
-	var ivPercent = ((100/45)*(parseInt(pokemon.individual_attack)+parseInt(pokemon.individual_defense)+parseInt(pokemon.individual_stamina))).toFixed(2);
+	var encounter = false;
+	var ivPercent = 100;
+	if (pokemon.individual_attack != null) {
+		encounter = true;
+		ivPercent = ((100/45)*(parseInt(pokemon.individual_attack)+parseInt(pokemon.individual_defense)+parseInt(pokemon.individual_stamina))).toFixed(2);
+	}
 	var marker = new google.maps.Marker({
 		position: {lat: parseFloat(pokemon.latitude), lng:parseFloat(pokemon.longitude)},
 		map: map,
 		icon: image,
-		label:{
-			color:getIvColor(ivPercent),
-			text:ivPercent+"%"
-		},
 		encounterId: pokemon.encounter_id,
 		ivPercent: ivPercent
 	});
-	var ivFormatted = ((100/45)*(parseInt(pokemon.individual_attack)+parseInt(pokemon.individual_defense)+parseInt(pokemon.individual_stamina))).toFixed(2);
+	if (encounter) {
+		marker.setLabel({
+			color:getIvColor(ivPercent),
+			text:ivPercent+"%"
+		});
+	}
 	var contentString = '<div>'+
-			'<h4> '+pokemon.name+' #'+pokemon.pokemon_id+' IV: '+ivFormatted+'% </h4>'+
+			'<h4> '+pokemon.name+' #'+pokemon.pokemon_id+ (encounter?' IV: '+ivPercent+'% ':'')+'</h4>'+
 			'<div id="bodyContent">'+
-				'<p class="disappear_time_display text-center">'+pokemon.disappear_time_real+'<span class="disappear_time_display_timeleft"></span></p>'+
-				
+				'<p class="disappear_time_display text-center">'+pokemon.disappear_time_real+'<span class="disappear_time_display_timeleft"></span></p>';
+	if (encounter) {
+		contentString +=
 				'<p></p>'+
 				'<div class="progress" style="height: 6px; width: 120px; margin-bottom: 10px; margin-top: 2px; margin-left: auto; margin-right: auto">'+
 					'<div title="'+locale.ivAttack+': '+pokemon.individual_attack+'" class="progress-bar progress-bar-danger" role="progressbar" aria-valuenow="'+pokemon.individual_attack+'" aria-valuemin="0" aria-valuemax="45" style="width: '+(((100/15)*pokemon.individual_attack)/3)+'%">'+
@@ -323,9 +330,9 @@ function addPokemonMarker(pokemon,pokeimg_suffix, locale) {
 					'</div>'+
 				'</div>'+
 				'<p class="text-center">('+pokemon.individual_attack+"/"+pokemon.individual_defense+"/"+pokemon.individual_stamina+')</p>'+
-				'<p class="text-center">'+pokemon.quick_move+"/"+pokemon.charge_move+'</p>'+
-			'</div>'+
-		'</div>';
+				'<p class="text-center">'+pokemon.quick_move+"/"+pokemon.charge_move+'</p>';
+		}
+		contentString +='</div>';
 
 	var infoWindow = new google.maps.InfoWindow({
 		content: contentString


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->
Removed label and info text when there is no iv data available.

Also removed extra calculation of the ivPercent 

My map does not have encounters and live map was showing a lot of NaN and nonsense
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running in my instance, need test in an instance with encounters


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)