### PR TITLE
Add migration countdown to nests page

### DIFF
--- a/core/js/nests.maps.js.php
+++ b/core/js/nests.maps.js.php
@@ -117,3 +117,18 @@ function getInfo(data) {
 			'</div>'
 	return info
 }
+
+
+Date.prototype.addDays = function(days) {
+	var d = new Date(this.valueOf());
+	d.setDate(d.getDate() + days);
+	return d;
+}
+
+$(function () {
+	var migration = new Date('2017-05-04T00:00:00Z');
+	while (migration < new Date()) migration = migration.addDays(14);
+	$('#migration').countdown(migration, function(event) {
+		$(this).html(event.strftime('%w <?= $locales->WEEKS ?> %d <?= $locales->DAYS ?> %H <?= $locales->HOURS ?> %M <?= $locales->MINUTES ?>'));
+	});
+});

--- a/core/js/nests.maps.js.php
+++ b/core/js/nests.maps.js.php
@@ -128,7 +128,7 @@ Date.prototype.addDays = function(days) {
 $(function () {
 	var migration = new Date('2017-05-04T00:00:00Z');
 	while (migration < new Date()) migration = migration.addDays(14);
-	$('#migration').countdown(migration, function(event) {
-		$(this).html(event.strftime('%w <?= $locales->WEEKS ?> %d <?= $locales->DAYS ?> %H <?= $locales->HOURS ?> %M <?= $locales->MINUTES ?>'));
-	});
+	$('#migration').countdown(migration, { precision: 60000 }).on('update.countdown', function(event) {
+		$(this).html(event.strftime('%w %!w:<?= $locales->WEEK ?>,<?= $locales->WEEKS ?>; %d %!d:<?= $locales->DAY ?>,<?= $locales->DAYS ?>; %H %!H:<?= $locales->HOUR ?>,<?= $locales->HOURS ?>; %M %!M:<?= $locales->MINUTE ?>,<?= $locales->MINUTES ?>;'));
+	}).countdown('start');
 });

--- a/core/json/locales/DE/translations.json
+++ b/core/json/locales/DE/translations.json
@@ -62,6 +62,7 @@
 "NAV_POKEDEX": "Alle Pokémon",
 "NAV_NESTS": "Nester",
 "NESTS_METADESC": "Finde Nester und frequente Spawnpunkte",
+"NESTS_MIGRATIONTEXT": "Die nächste <strong>Nest-Migration</strong> findet statt in",
 "NESTS_TITLE": "<strong>Nester</strong> und frequente Spawnpunkte",
 "NESTS_PER_DAY": "pro Tag",
 "NEVER": "Noch nie",

--- a/core/json/locales/EN/translations.json
+++ b/core/json/locales/EN/translations.json
@@ -61,6 +61,7 @@
 "NAV_POKEDEX": "All Pokémon",
 "NAV_NESTS": "Nests",
 "NESTS_METADESC": "Find nests and frequent spawnpoints",
+"NESTS_MIGRATIONTEXT": "The next <strong>nest migration</strong> happens in",
 "NESTS_TITLE": "<strong>Nests</strong> and frequent spawnpoints",
 "NESTS_PER_DAY": "per day",
 "NEVER": "Never",

--- a/index.php
+++ b/index.php
@@ -247,6 +247,7 @@ include_once('core/process/data.loader.php');
 				case 'nests':
 					?>
 
+					<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.countdown/2.2.0/jquery.countdown.min.js"></script>
 					<script src="core/js/nests.maps.js.php"></script>
 					<script src="https://maps.googleapis.com/maps/api/js?key=<?= $config->system->GMaps_Key ?>&libraries=visualization&callback=initMap"></script>
 

--- a/pages/nests.page.php
+++ b/pages/nests.page.php
@@ -4,13 +4,11 @@
 			<h1>
 				<?= $locales->NESTS_TITLE ?>
 			</h1>
-
+			<br>
+			<h4><?= $locales->NESTS_MIGRATIONTEXT ?> <span id="migration"></span></h4>
 		</div>
 	</div>
 </header>
-
-
-
 
 <div class="row">
 	<div class="col-md-12 text-center">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Implements #232  

## Description
Add a countdown to nests page that shows the remaining time to the next nest migration.

## Motivation and Context
Let users know when the new nests will appear.

## How Has This Been Tested?
Tested at own instance.
Only added German and English texts. Other languages have to be updated too.

## Screenshots (if appropriate):
![bildschirmfoto 2017-04-20 um 11 46 15](https://cloud.githubusercontent.com/assets/727517/25225260/1482bc78-25c1-11e7-9631-f81242ce71a0.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
