### PR TITLE
Trim dashboard json files to last 7 days (fix #169)

### DIFF
--- a/core/cron/captcha.cron.php
+++ b/core/cron/captcha.cron.php
@@ -8,6 +8,8 @@
 $captcha_file	= SYS_PATH.'/core/json/captcha.stats.json';
 if (is_file($captcha_file)) {
 	$capdatas	= json_decode(file_get_contents($captcha_file), true);
+	// Trim json stats files to last 7 days of data
+	$capdatas = trim_stats_json($capdatas, $timestamp_lastweek);
 }
 
 

--- a/core/cron/crontabs.include.php
+++ b/core/cron/crontabs.include.php
@@ -47,8 +47,15 @@ if (is_file($pokemonstats_file)) {
 	$pokedatas	= json_decode(file_get_contents($pokemonstats_file), true);
 }
 
-$timestamp	= time();
+$timestamp = time();
+$timestamp_lastweek = $timestamp - 604800;
 
+// Trim all json stats files to last 7 days of data
+$gymsdatas = trim_stats_json($gymsdatas, $timestamp_lastweek);
+$stopdatas = trim_stats_json($stopdatas, $timestamp_lastweek);
+$pokedatas = trim_stats_json($pokedatas, $timestamp_lastweek);
+
+// Update json stats files
 include_once(SYS_PATH.'/core/cron/gym.cron.php');
 include_once(SYS_PATH.'/core/cron/pokemon.cron.php');
 include_once(SYS_PATH.'/core/cron/pokestop.cron.php');

--- a/functions.php
+++ b/functions.php
@@ -114,3 +114,21 @@ function file_update_ago($filepath)
 	// file doesn't exist yet!
 	return PHP_INT_MAX;
 }
+
+########################################################################
+// Only keep data after $timestamp in $array (compared to 'timestamp' key)
+// @param $array     => array (mandatory)
+// @param $timestamp => int (mandatory)
+//
+// Return trimmed array
+########################################################################
+
+function trim_stats_json($array, $timestamp)
+{
+	foreach($array as $key => $value) {
+		if ($value['timestamp'] < $timestamp) {
+			unset($array[$key]);
+		}
+	}
+	return $array;
+}


### PR DESCRIPTION
Trim json stats files to last 7 days. Fixes #169

- improves loading performance
- less bandwidth usage

```
# before
-rw-r--r-- 1 wwwrun www 400K Apr 21 02:25 core/json/captcha.stats.json
-rw-r--r-- 1 wwwrun www 4.7M Apr 21 02:24 core/json/gym.stats.json
-rw-r--r-- 1 wwwrun www 1.3M Apr 21 02:25 core/json/pokemon.stats.json
-rw-r--r-- 1 wwwrun www 1.2M Apr 21 02:25 core/json/pokestop.stats.json

# after
-rw-r--r-- 1 wwwrun www  28K Apr 21 02:27 core/json/captcha.stats.json
-rw-r--r-- 1 wwwrun www 114K Apr 21 02:27 core/json/gym.stats.json
-rw-r--r-- 1 wwwrun www  78K Apr 21 02:27 core/json/pokemon.stats.json
-rw-r--r-- 1 wwwrun www  35K Apr 21 02:27 core/json/pokestop.stats.json
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
