### PR TITLE
Lower PHP and JS memory usage

### DIFF
--- a/core/js/gym.maps.js
+++ b/core/js/gym.maps.js
@@ -8,9 +8,9 @@ function initMap()
 			'async': true,
 			'type': "GET",
 			'global': false,
-			'dataType': 'text',
+			'dataType': 'json',
 			'url': "core/process/aru.php",
-			'data': { 'request': "", 'target': 'arrange_url', 'method': 'method_target', 'type' : 'gym_map' }}).done(function (data) {
+			'data': { 'request': "", 'target': 'arrange_url', 'method': 'method_target', 'type' : 'gym_map' }}).done(function (gyms) {
 			
 			
 			// Get website variables
@@ -20,15 +20,6 @@ function initMap()
 					var longitude = Number(variables['system']['map_center_long']);
 					var zoom_level = Number(variables['system']['zoom_level']);
 				
-					// Convert return to JSON Array
-				
-					var locations = JSON.parse(data);
-					var arr = [];
-				
-					for (i = 0; i < locations.length; i++) {
-						arr.push(JSON.parse(locations[i]));
-					}
-					
 					var map = new google.maps.Map(document.getElementById('map'), {
 						center: {
 							lat: latitude,
@@ -76,17 +67,17 @@ function initMap()
 				
 					var marker, i;
 			
-					for (i = 0; i < arr.length; i++) {
+					for (i = 0; i < gyms.length; i++) {
 						marker = new google.maps.Marker({
-							position: new google.maps.LatLng(arr[i][2], arr[i][3]),
+							position: new google.maps.LatLng(gyms[i][2], gyms[i][3]),
 							map: map,
-							icon: 'core/img/'+arr[i][1],
+							icon: 'core/img/'+gyms[i][1],
 						});
 					
 					
 						google.maps.event.addListener(marker, 'click', (function (marker, i) {
 							return function () {
-								infowindow.setContent(arr[i][0]);
+								infowindow.setContent(gyms[i][0]);
 								infowindow.open(map, marker);
 								$.ajax({
 									'async': true,
@@ -99,7 +90,7 @@ function initMap()
 										'target': 'arrange_url',
 										'method': 'method_target',
 										'type' : 'gym_defenders',
-										'gym_id' : arr[i][5]
+										'gym_id' : gyms[i][4]
 									},
 									'success': function (data) {
 										setGymDetails(data);

--- a/core/js/pokestops.maps.js
+++ b/core/js/pokestops.maps.js
@@ -8,10 +8,10 @@ function initMap()
 		'async': true,
 		'type': "GET",
 		'global': false,
-		'dataType': 'text',
+		'dataType': 'json',
 		'url': "core/process/aru.php",
 		'data': { 'request': "", 'target': 'arrange_url', 'method': 'method_target', 'type' : 'pokestop' },
-		'success': function (data) {
+		'success': function (pokestops) {
 			
 		
 			$.getJSON("core/json/variables.json", function (variables) {
@@ -19,16 +19,6 @@ function initMap()
 				var longitude = Number(variables['system']['map_center_long']);
 				var zoom_level = Number(variables['system']['zoom_level']);
 
-		 
-				// Convert return to JSON Array
-			
-				locations = JSON.parse(data);
-				var arr = [];
-			
-				for (i = 0; i < locations.length; i++) {
-					arr.push(JSON.parse(locations[i]));
-				}
-				
 				var map = new google.maps.Map(document.getElementById('map'), {
 					center: {
 						lat: latitude,
@@ -65,16 +55,16 @@ function initMap()
 			
 				var marker, i;
 		
-				for (i = 0; i < arr.length; i++) {
+				for (i = 0; i < pokestops.length; i++) {
 					marker = new google.maps.Marker({
-						position: new google.maps.LatLng(arr[i][2], arr[i][3]),
+						position: new google.maps.LatLng(pokestops[i][2], pokestops[i][3]),
 						map: map,
-						icon: 'core/img/'+arr[i][1]
+						icon: 'core/img/'+pokestops[i][1]
 					});
 		
 					google.maps.event.addListener(marker, 'click', (function (marker, i) {
 							return function () {
-								infowindow.setContent(arr[i][0]);
+								infowindow.setContent(pokestops[i][0]);
 								infowindow.open(map, marker);
 							}
 					})(marker, i));

--- a/core/js/pokestops.maps.js
+++ b/core/js/pokestops.maps.js
@@ -1,9 +1,6 @@
 /** global: google */
 function initMap()
 {
-
-	var locations;
-
 	$.ajax({
 		'async': true,
 		'type': "GET",

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -6,7 +6,7 @@
 
 $pos = !empty($_SERVER['HTTP_REFERER']) && strpos($_SERVER['HTTP_REFERER'], getenv('HTTP_HOST'));
 
-if ($pos===false) {
+if ($pos === false) {
 	http_response_code(401);
 	die('Restricted access');
 }
@@ -44,7 +44,7 @@ if ($mysqli->connect_error != '') {
 $mysqli->set_charset('utf8');
 $request = "";
 if (isset($_GET['type'])) {
-$request 	= $_GET['type'];
+	$request = $_GET['type'];
 }
 $postRequest = "";
 if (isset($_POST['type'])) {
@@ -124,15 +124,10 @@ switch ($request) {
 		// Neutral
 		$values[] = $data->total;
 
-
 		header('Content-Type: application/json');
-		$json = json_encode($values);
-
-		echo $json;
-
+		echo json_encode($values);
 
 		break;
-
 
 
 	####################################
@@ -262,10 +257,11 @@ switch ($request) {
 				break;
 			}
 		}
+
 		header('Content-Type: application/json');
 		echo json_encode($total_spawns);
-		break;
 
+		break;
 
 
 	####################################
@@ -282,7 +278,7 @@ switch ($request) {
 		}
 		$result 	= $mysqli->query($req);
 
-		$i=0;
+		$pokestops = [];
 
 		while ($data = $result->fetch_object()) {
 			if ($data->lure_expiration >= $data->now) {
@@ -293,24 +289,18 @@ switch ($request) {
 				$text = $locales->POKESTOPS_MAP_REGULAR;
 			}
 
-			$temp[$i][] = $text;
-			$temp[$i][] = $icon;
-			$temp[$i][] = $data->latitude;
-			$temp[$i][] = $data->longitude;
-			$temp[$i][] = $i;
-
-			$temp_json[] = json_encode($temp[$i]);
-
-
-			$i++;
+			$pokestops[] = [
+				$text,
+				$icon,
+				$data->latitude,
+				$data->longitude
+			];
 		}
 
-		$return = json_encode($temp_json);
-
-		echo $return;
+		header('Content-Type: application/json');
+		echo json_encode($pokestops);
 
 		break;
-
 
 
 	####################################
@@ -335,13 +325,11 @@ switch ($request) {
 			$return[]	= $data->average_points;
 		}
 
-		$json = json_encode($return);
-
 		header('Content-Type: application/json');
-		echo $json;
-
+		echo json_encode($return);
 
 		break;
+
 
 	####################################
 	//
@@ -354,8 +342,7 @@ switch ($request) {
 		$req 		= "SELECT gym_id, team_id, guard_pokemon_id, gym_points, latitude, longitude, (CONVERT_TZ(last_scanned, '+00:00', '".$time_offset."')) as last_scanned FROM gym";
 		$result 	= $mysqli->query($req);
 
-
-		$i=0;
+		$gyms = [];
 
 		while ($data = $result->fetch_object()) {
 			// Team
@@ -430,25 +417,18 @@ switch ($request) {
 
 			';
 
-
-
-			$temp[$i][] = $html;
-			$temp[$i][] = $icon;
-			$temp[$i][] = $data->latitude;
-			$temp[$i][] = $data->longitude;
-			$temp[$i][] = $i;
-			$temp[$i][] = $data->gym_id;
-			$temp[$i][] = $data->gym_level;
-
-			$temp_json[] = json_encode($temp[$i]);
-
-
-			$i++;
+			$gyms[] = [
+				$html,
+				$icon,
+				$data->latitude,
+				$data->longitude,
+				$data->gym_id,
+				$data->gym_level
+			];
 		}
 
-		$return = json_encode($temp_json);
-
-		echo $return;
+		header('Content-Type: application/json');
+		echo json_encode($gyms);
 
 		break;
 
@@ -568,12 +548,12 @@ switch ($request) {
 			$i++;
 		}
 		$gymData['infoWindow'] = $gymData['infoWindow'].'</div>';
-		$return = json_encode($gymData);
 
-		echo $return;
-
+		header('Content-Type: application/json');
+		echo json_encode($gymData);
 
 		break;
+
 
 	case 'trainer':
 		$name = "";
@@ -667,23 +647,23 @@ switch ($request) {
 		$locale["ivDefense"] = $locales->IV_DEFENSE;
 		$locale["ivStamina"] = $locales->IV_STAMINA;
 		$json['locale'] = $locale;
-		$return = json_encode($json);
 
-		echo $return;
+		header('Content-Type: application/json');
+		echo json_encode($json);
 
 		break;
+
 
 	case 'pokemon_slider_init':
 		$req 		= "SELECT MIN(pokemon.disappear_time) as min, MAX(pokemon.disappear_time) as max from pokemon";
 		$result 	= $mysqli->query($req);
-		$data 		= $result->fetch_object();
-		$bounds 	= $data;
+		$bounds		= $result->fetch_object();
 
 		header('Content-Type: application/json');
-		$json = json_encode($bounds);
+		echo json_encode($bounds);
 
-		echo $json;
 		break;
+
 
 	case 'pokemon_heatmap_points':
 		$json="";
@@ -704,10 +684,10 @@ switch ($request) {
 		}
 
 		header('Content-Type: application/json');
-
 		echo $json;
 
 		break;
+
 
 	case 'pokemon_graph_data':
 		$json="";
@@ -731,10 +711,10 @@ switch ($request) {
 		}
 
 		header('Content-Type: application/json');
-
 		echo $json;
 
 		break;
+
 
 	case 'postRequest':
 		break;
@@ -742,9 +722,9 @@ switch ($request) {
 	default:
 		echo "What do you mean?";
 		exit();
-
 	break;
 }
+
 if ($postRequest!="") {
 	switch ($postRequest) {
 		case 'pokemon_live':


### PR DESCRIPTION
This should lower the memory usage, cpu usage on client and server side and improve page loading speed
- don't json_encode data twice in PHP (this was done in a loop!)
- don't create arrays twice in PHP
- don't create arrays twice in JS
- set all json headers
- remove unnecessary data from json
- this allows me to load 150k+ pokestops and 30k gyms without a problem, before this wasn't possible, because PHP ran out of memory.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)