### PR TITLE
Add page to explore all changes of gyms over time

### DIFF
--- a/core/css/style.css
+++ b/core/css/style.css
@@ -458,11 +458,11 @@ trainers details styles
 trainers search styles
 ****************/
 
-#searchTrainer button {
+#searchTrainer button, #searchGyms button {
 	height: 40px;
 }
 
-#searchTrainer input {
+#searchTrainer input, #searchGyms input {
 	height: 40px;
 }
 
@@ -487,3 +487,77 @@ trainers search styles
 	100% { transform: rotate(360deg); }
 }
 
+#gymsContainer td  {
+	vertical-align: middle;
+	line-height: 2em;
+}
+
+#gymsContainer .gymhistory table td:first-child, #gymsContainer .gymhistory table th:first-child {
+	padding-left: 10px;
+}
+
+#gymsContainer td.level {
+	width: 68px;
+}
+
+#gymsContainer td.level img {
+	height: 2em;
+	margin-right: .5em;
+}
+
+#gymsContainer td.loss {
+	color: rgb(210,118,118);
+}
+
+#gymsContainer td.gain {
+	color: rgb(62,150,62);
+}
+
+#gymsContainer td ul {
+	margin-bottom: -8px;
+	min-height: 71px;
+}
+
+#gymsContainer td ul li {
+	line-height: initial;
+	width: 5em;
+	overflow: hidden;
+	text-align: center;
+	border-radius: 5px;
+	margin-right: 2px;
+}
+
+#gymsTable > thead > tr > th:nth-child(1) {
+		width: 100px;
+}
+
+#gymsTable > thead > tr > th:nth-child(2) {
+		width: 180px;
+}
+
+@media (max-width: 768px) {
+	#gymsContainer td ul li {
+		display: none;
+	}
+	#gymsTable > thead > tr > th:last-child, #gymsTable > tbody > tr:nth-child(2n-1) > td:last-child {
+		display: none;
+	}
+	#gymsTable > thead > tr > th:nth-child(1), #gymsTable > thead > tr > th:nth-child(2) {
+		width: initial;
+	}
+}
+
+#gymsContainer td ul li.new {
+	background-color: rgba(62,150,62,.25);
+	display: inline-block !important;
+}
+
+#gymsContainer td ul li.old {
+	background-color: rgba(210,118,118,.25);
+	display: inline-block !important;
+}
+
+.no-link {
+	text-decoration: none;
+	color: inherit;
+}

--- a/core/css/style.css
+++ b/core/css/style.css
@@ -527,11 +527,11 @@ trainers search styles
 }
 
 #gymsTable > thead > tr > th:nth-child(1) {
-		width: 100px;
+	width: 100px;
 }
 
 #gymsTable > thead > tr > th:nth-child(2) {
-		width: 180px;
+	width: 180px;
 }
 
 @media (max-width: 768px) {

--- a/core/css/style.css
+++ b/core/css/style.css
@@ -487,7 +487,7 @@ trainers search styles
 	100% { transform: rotate(360deg); }
 }
 
-#gymsContainer td  {
+#gymsContainer td {
 	vertical-align: middle;
 	line-height: 2em;
 }
@@ -501,7 +501,6 @@ trainers search styles
 }
 
 #gymsContainer td.level img {
-	height: 2em;
 	margin-right: .5em;
 }
 
@@ -514,12 +513,12 @@ trainers search styles
 }
 
 #gymsContainer td ul {
-	margin-bottom: -8px;
+	margin-bottom: 0;
 	min-height: 71px;
+	line-height: initial;
 }
 
 #gymsContainer td ul li {
-	line-height: initial;
 	width: 5em;
 	overflow: hidden;
 	text-align: center;

--- a/core/css/style.css
+++ b/core/css/style.css
@@ -514,7 +514,7 @@ trainers search styles
 
 #gymsContainer td ul {
 	margin-bottom: 0;
-	min-height: 71px;
+	min-height: 65px;
 	line-height: initial;
 }
 

--- a/core/inc/meta.inc.php
+++ b/core/inc/meta.inc.php
@@ -218,6 +218,30 @@
 
 		<?php
 			break;
+
+		case 'gymhistory':
+		?>
+
+		<title><?= $config->infos->site_name ?> | Gym History</title>
+
+		<link rel="canonical" href="<?= HOST_URL ?>gymhistory" />
+		<base href="<?= HOST_URL ?>">
+
+		<meta property="og:locale" content="en_US" />
+		<meta property="og:type" content="website" />
+		<meta property="og:title" content="<?= $config->infos->site_name ?> | Gym History" />
+		<meta property="og:description" content="Gym History" />
+		<meta property="og:url" content="<?= HOST_URL ?>gymhistory" />
+		<meta property="og:site_name" content="<?= $config->infos->site_name ?>" />
+		<meta property="og:image" content="<?= HOST_URL ?>core/img/logo.jpg" />
+
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:description" content="Gym History" />
+		<meta name="twitter:title" content="<?= $config->infos->site_name ?> | Gym History" />
+		<meta name="twitter:image" content="<?= HOST_URL ?>core/img/logo.jpg" />
+
+		<?php
+			break;
 	}
 }
 

--- a/core/js/gymhistory.content.js
+++ b/core/js/gymhistory.content.js
@@ -1,0 +1,225 @@
+/** global: gymName */
+
+var gymRanks = [
+	{ level : 1,  prestigeMax : 2000,  prestigeMin : 0 },
+	{ level : 2,  prestigeMax : 4000,  prestigeMin : 2000 },
+	{ level : 3,  prestigeMax : 8000,  prestigeMin : 4000 },
+	{ level : 4,  prestigeMax : 12000, prestigeMin : 8000 },
+	{ level : 5,  prestigeMax : 16000, prestigeMin : 12000 },
+	{ level : 6,  prestigeMax : 20000, prestigeMin : 16000 },
+	{ level : 7,  prestigeMax : 30000, prestigeMin : 20000 },
+	{ level : 8,  prestigeMax : 40000, prestigeMin : 30000 },
+	{ level : 9,  prestigeMax : 50000, prestigeMin : 40000 },
+	{ level : 10, prestigeMax : 52000, prestigeMin : 50000 }
+];
+
+$(function () {
+
+	$.getJSON("core/json/variables.json", function(variables) {
+		var pokeimg_suffix = variables['system']['pokeimg_suffix'];
+
+		$('.gymLoader').hide();
+		var page = 0;
+		var teamSelector = ''; //''=all;0=neutral;1=Blue;2=Red;3=Yellow
+		var rankingFilter = 0; //0=Level & Gyms; 1=Level; 2=Gyms
+
+		$('input#name').filter(':visible').val(gymName);
+		loadGyms(page, $('input#name').filter(':visible').val(), null, null, pokeimg_suffix, true);
+
+		page++;
+		$('#loadMoreButton').click(function () {
+			loadGyms(page, $('input#name').filter(':visible').val(), teamSelector, rankingFilter, pokeimg_suffix, true);
+			page++;
+		});
+		$("#searchGyms").submit(function ( event ) {
+			page = 0;
+			$('#gymsContainer tr:not(.gymsTemplate)').remove();
+			loadGyms(page, $('input#name').filter(':visible').val(), teamSelector, rankingFilter, pokeimg_suffix, true);
+			page++;
+			event.preventDefault();
+		});
+		$(".teamSelectorItems").click(function ( event ) {
+			switch ($(this).attr("id")) {
+				case "NeutralTeamsFilter":
+					teamSelector=0;
+					break;
+				case "BlueTeamFilter":
+					teamSelector=1;
+					break;
+				case "RedTeamFilter":
+					teamSelector=2;
+					break;
+				case "YellowFilter":
+					teamSelector=3;
+					break;
+				default:
+					teamSelector='';
+			}
+			$("#teamSelectorText").html($(this).html());
+			event.preventDefault();
+			$("#searchGyms").submit();
+
+		});
+		$(".rankingOrderItems").click(function ( event ) {
+			switch ($(this).attr("id")) {
+				case "changedFirst":
+					rankingFilter=0;
+					break;
+				case "nameFirst":
+					rankingFilter=1;
+					break;
+				case "prestigeFirst":
+					rankingFilter=2;
+					break;
+				default:
+					rankingFilter=0;
+			}
+			$("#rankingOrderText").html($(this).html());
+			event.preventDefault();
+			$("#searchGyms").submit();
+
+		});
+		window.onpopstate = function() {
+			if (window.history.state && "gym" === window.history.state.page) {
+				$('#gymsContainer').empty();
+				$('input#name').filter(':visible').val(window.history.state.name);
+				loadGyms(0, $('input#name').filter(':visible').val(), teamSelector, rankingFilter, pokeimg_suffix, false);
+			}
+			else{
+				window.history.back();
+			}
+		};
+
+	});
+});
+
+function loadGyms(page, name, teamSelector, rankingFilter, pokeimg_suffix, stayOnPage) {
+	$('.gymLoader').show();
+
+	if (stayOnPage) {
+		// build a state for this name
+		var state = {name: name, page: 'Gym History'};
+		window.history.pushState(state, 'Gym History', 'gymhistory?name=' + name);
+	}
+	$.ajax({
+		'async': true,
+		'type': "GET",
+		'global': false,
+		'dataType': 'json',
+		'url': "core/process/aru.php",
+		'data': {
+			'request': '',
+			'target': 'arrange_url',
+			'method': 'method_target',
+			'type' : 'gyms',
+			'page' : page,
+			'name' : name,
+			'team' : teamSelector,
+			'ranking' :rankingFilter
+		}
+	}).done(function (data) {
+		var internalIndex = 0;
+		$.each(data.gyms, function (idx, gym) {
+			internalIndex++
+			printGym(gym, pokeimg_suffix, data.locale);
+		});
+		if (internalIndex < 10) {
+			$('#loadMoreButton').hide();
+		} else {
+			$('#loadMoreButton').removeClass('hidden');
+			$('#loadMoreButton').show();
+		}
+		$('.gymLoader').hide();
+	});
+}
+
+function loadGymHistory(page, gym_id, pokeimg_suffix) {
+	$('.gymLoader').show();
+
+	$.ajax({
+		'async': true,
+		'type': "GET",
+		'global': false,
+		'dataType': 'json',
+		'url': "core/process/aru.php",
+		'data': {
+			'request': '',
+			'target': 'arrange_url',
+			'method': 'method_target',
+			'type' : 'gymhistory',
+			'page' : page,
+			'gym_id' : gym_id
+		}
+	}).done(function (data) {
+		var internalIndex = 0;
+		$.each(data.entries, function(idx, entry) {
+			internalIndex++
+			printGymHistory(gym_id, entry, pokeimg_suffix, data.locale);
+		});
+		$('#gymHistory_'+gym_id).addClass('active').show();
+		if (internalIndex < 10) {
+			$('#gymHistory_'+gym_id).find('.loadMoreButtonHistory').hide();
+		} else {
+			$('#gymHistory_'+gym_id).find('.loadMoreButtonHistory').removeClass('hidden');
+			$('#gymHistory_'+gym_id).find('.loadMoreButtonHistory').data('page', page+1).show();
+		}
+		$('.gymLoader').hide();
+	});
+}
+
+function printPokemonList(pokemons, pokeimg_suffix, hide_unchanged) {
+	var gymPokemon = $('<ul>',{class: 'list-inline'});
+	$.each(pokemons, function(idx, pokemon) {
+		if (!hide_unchanged || pokemon.class) {
+			var list = $('<li>', {class: pokemon.class});
+			list.append($('<a>', { class: 'no-link', href : 'pokemon/'+pokemon.pokemon_id }).append($('<img />', { src: 'core/pokemons/'+pokemon.pokemon_id+pokeimg_suffix }).css('height', '2em')));
+			list.append($('<br><span class="small">'+pokemon.cp+' CP</span>'));
+			list.append($('<br><span style="font-size:70%"><a href="trainer?name='+pokemon.trainer_name+'" class="no-link">'+pokemon.trainer_name+'</a></span>'));
+			gymPokemon.append(list);
+		}
+	});
+	return gymPokemon;
+}
+
+function printGymHistory(gym_id, entry, pokeimg_suffix, locale) {
+	var gymLevel = gymRanks.find(r => r.prestigeMin <= entry.gym_points && r.prestigeMax > entry.gym_points) || { level : 10 };
+	var gymHistory = $('<tr>').css('border-bottom', '2px solid '+(entry.team_id=='3'?'#ffbe08':entry.team_id=='2'?'#ff7676':entry.team_id=='1'?'#00aaff':'#ddd'));
+	gymHistory.append($('<td>',{text: entry.last_modified}));
+	gymHistory.append($('<td>',{text: gymLevel.level, class: 'level'}).prepend($('<img />', {src:'core/img/map_'+(entry.team_id=='1'?'blue':entry.team_id=='2'?'red':entry.team_id=='3'?'yellow':'white')+'.png'})));
+	gymHistory.append($('<td>',{text: parseInt(entry.gym_points).toLocaleString('de-DE'), class: entry.class}).append(
+		entry.gym_points_diff !== 0 ? $('<span class="small"> ('+(entry.gym_points_diff > 0 ? '+' : '')+entry.gym_points_diff+')</span>') : null
+	));
+	var gymPokemon = printPokemonList(entry.pokemon, pokeimg_suffix, false);
+	gymHistory.append($('<td>').append(gymPokemon));
+	$('#gymHistory_'+gym_id).find('tbody').append(gymHistory);
+}
+
+function printGym(gym, pokeimg_suffix, locale) {
+	var gymLevel = gymRanks.find(r => r.prestigeMin <= gym.gym_points && r.prestigeMax > gym.gym_points) || { level : 10 };
+	var gymsInfos = $('<tr>',{id: 'gymInfos_'+gym.gym_id}).css('cursor', 'pointer').css('border-bottom', '2px solid '+(gym.team_id=='3'?'#ffbe08':gym.team_id=='2'?'#ff7676':gym.team_id=='1'?'#00aaff':'#ddd')).click(function() {
+		if (!$('#gymHistory_'+gym.gym_id).hasClass('active')) {
+			$('#gymsContainer').find('.gymhistory').removeClass('active').hide().find('tbody tr').remove();
+			loadGymHistory(0, gym.gym_id, pokeimg_suffix);
+		} else {
+			$('#gymHistory_'+gym.gym_id).removeClass('active').hide().find('tbody tr').remove();
+		}
+	});
+	gymsInfos.append($('<td>',{text: gym.last_modified}));
+	if (gym.name.length > 50) gym.name = gym.name.substr(0, 50) + '…';
+	gymsInfos.append($('<td>',{text: gym.name}));
+	gymsInfos.append($('<td>',{text: gymLevel.level, class: 'level'}).prepend($('<img />', {src:'core/img/map_'+(gym.team_id=='1'?'blue':gym.team_id=='2'?'red':gym.team_id=='3'?'yellow':'white')+'.png'})));
+	gymsInfos.append($('<td>',{text: parseInt(gym.gym_points).toLocaleString('de-DE')}));
+	var gymPokemon = printPokemonList(gym.pokemon, pokeimg_suffix, false);
+	gymsInfos.append($('<td>').append(gymPokemon));
+	$('#gymsContainer').append(gymsInfos);
+	var historyTable = $('<table>',{class: 'table'});
+	historyTable.append('<thead><tr><th style="min-width:7em">Time</th><th>Level</th><th>Prestige</th><th>Pokémon</th></tr></thead>');
+	historyTable.append('<tbody></tbody>');
+	historyTable.append('<tfoot><tr class="loadMore text-center"><td colspan="4"><button class="loadMoreButtonHistory btn btn-default btn-sm hidden">Load more</button></td></tr></tfoot>');
+	historyTable.find('.loadMoreButtonHistory').data('page', 0).click(function() {
+		loadGymHistory($(this).data('page'), gym.gym_id, pokeimg_suffix);
+	});
+	var row = $('<td>',{colspan: 6});
+	row.append(historyTable);
+	$('#gymsContainer').append($('<tr>', {id: 'gymHistory_'+gym.gym_id, class: 'gymhistory'}).hide().append(row));
+}

--- a/core/js/gymhistory.content.js
+++ b/core/js/gymhistory.content.js
@@ -84,8 +84,7 @@ $(function () {
 				$('#gymsContainer').empty();
 				$('input#name').filter(':visible').val(window.history.state.name);
 				loadGyms(0, $('input#name').filter(':visible').val(), teamSelector, rankingFilter, pokeimg_suffix, false);
-			}
-			else{
+			} else {
 				window.history.back();
 			}
 		};
@@ -205,7 +204,7 @@ function printGym(gym, pokeimg_suffix, locale) {
 		}
 	});
 	gymsInfos.append($('<td>',{text: gym.last_modified}));
-	if (gym.name.length > 50) gym.name = gym.name.substr(0, 50) + '…';
+	if (gym.name.length > 50) { gym.name = gym.name.substr(0, 50) + '…'; }
 	gymsInfos.append($('<td>',{text: gym.name}));
 	gymsInfos.append($('<td>',{text: gymLevel.level, class: 'level'}).prepend($('<img />', {src:'core/img/map_'+(gym.team_id=='1'?'blue':gym.team_id=='2'?'red':gym.team_id=='3'?'yellow':'white')+'.png'})));
 	gymsInfos.append($('<td>',{text: parseInt(gym.gym_points).toLocaleString('de-DE')}));

--- a/core/js/gymhistory.content.js
+++ b/core/js/gymhistory.content.js
@@ -18,8 +18,9 @@ $(function () {
 		var pokeimg_suffix = variables['system']['pokeimg_suffix'];
 
 		$('.gymLoader').hide();
+
 		var page = 0;
-		var teamSelector = ''; //''=all;0=neutral; 1=Blue; 2=Red; 3=Yellow
+		var teamSelector = ''; //''=all; 0=neutral; 1=Blue; 2=Red; 3=Yellow
 		var rankingFilter = 0; //0=Level & Gyms; 1=Level; 2=Gyms
 
 		$('input#name').filter(':visible').val(gymName);
@@ -81,7 +82,8 @@ $(function () {
 				$('input#name').filter(':visible').val(window.history.state.name);
 				page = 0;
 				$('#gymsContainer').empty();
-				$('#loadMoreButton').trigger('click');
+				loadGyms(page, $('input#name').filter(':visible').val(), teamSelector, rankingFilter, pokeimg_suffix, false);
+				page++;
 			} else {
 				window.history.back();
 			}
@@ -125,7 +127,8 @@ function loadGyms(page, name, teamSelector, rankingFilter, pokeimg_suffix, stayO
 }
 
 function loadGymHistory(page, gym_id, pokeimg_suffix) {
-	$('.gymLoader').show();
+	$('#gymHistory_'+gym_id).addClass('active').show();
+	$('#gymHistory_'+gym_id).find('.gymHistoryLoader').show();
 	$.ajax({
 		'async': true,
 		'type': 'GET',
@@ -143,13 +146,12 @@ function loadGymHistory(page, gym_id, pokeimg_suffix) {
 			internalIndex++
 			printGymHistory(gym_id, entry, pokeimg_suffix, data.locale);
 		});
-		$('#gymHistory_'+gym_id).addClass('active').show();
 		if (internalIndex < 10) {
 			$('#gymHistory_'+gym_id).find('.loadMoreButtonHistory').hide();
 		} else {
 			$('#gymHistory_'+gym_id).find('.loadMoreButtonHistory').removeClass('hidden').data('page', page+1).show();
 		}
-		$('.gymLoader').hide();
+		$('#gymHistory_'+gym_id).find('.gymHistoryLoader').hide();
 	});
 }
 
@@ -208,7 +210,7 @@ function printGym(gym, pokeimg_suffix, locale) {
 	var historyTable = $('<table>',{class: 'table'});
 	historyTable.append('<thead><tr><th style="min-width:7em">Time</th><th>Level</th><th>Prestige</th><th>Pokémon</th></tr></thead>');
 	historyTable.append('<tbody></tbody>');
-	historyTable.append('<tfoot><tr class="loadMore text-center"><td colspan="4"><button class="loadMoreButtonHistory btn btn-default btn-sm hidden">Load more</button></td></tr></tfoot>');
+	historyTable.append('<tfoot><tr class="loadMore text-center"><td colspan="4"><button class="loadMoreButtonHistory btn btn-default btn-sm hidden">Load more</button></td></tr><tr class="gymHistoryLoader"><td colspan="4"><div class="loader"></div></td></tr></tfoot>');
 	historyTable.find('.loadMoreButtonHistory').data('page', 0).click(function() {
 		loadGymHistory($(this).data('page'), gym.gym_id, pokeimg_suffix);
 	});

--- a/core/js/gymhistory.content.js
+++ b/core/js/gymhistory.content.js
@@ -193,14 +193,21 @@ function printGymHistory(gym_id, entry, pokeimg_suffix, locale) {
 	$('#gymHistory_'+gym_id).find('tbody').append(gymHistory);
 }
 
+function hideGymHistoryTables(gymHistoryTables) {
+	gymHistoryTables.removeClass('active').hide();
+	gymHistoryTables.find('tbody tr').remove();
+	gymHistoryTables.find('.loadMoreButtonHistory').hide();
+	gymHistoryTables.find('.gymHistoryLoader').hide();
+}
+
 function printGym(gym, pokeimg_suffix, locale) {
 	var gymLevel = gymRanks.find(r => r.prestigeMin <= gym.gym_points && r.prestigeMax > gym.gym_points) || { level : 10 };
 	var gymsInfos = $('<tr>',{id: 'gymInfos_'+gym.gym_id}).css('cursor', 'pointer').css('border-bottom', '2px solid '+(gym.team_id=='3'?'#ffbe08':gym.team_id=='2'?'#ff7676':gym.team_id=='1'?'#00aaff':'#ddd')).click(function() {
 		if (!$('#gymHistory_'+gym.gym_id).hasClass('active')) {
-			$('#gymsContainer').find('.gymhistory').removeClass('active').hide().find('tbody tr').remove();
+			hideGymHistoryTables($('#gymsContainer').find('.gymhistory'));
 			loadGymHistory(0, gym.gym_id, pokeimg_suffix);
 		} else {
-			$('#gymHistory_'+gym.gym_id).removeClass('active').hide().find('tbody tr').remove();
+			hideGymHistoryTables($('#gymHistory_'+gym.gym_id));
 		}
 	});
 	gymsInfos.append($('<td>',{text: gym.last_modified}));

--- a/core/js/gymhistory.content.js
+++ b/core/js/gymhistory.content.js
@@ -14,102 +14,95 @@ var gymRanks = [
 ];
 
 $(function () {
-
 	$.getJSON("core/json/variables.json", function(variables) {
 		var pokeimg_suffix = variables['system']['pokeimg_suffix'];
 
 		$('.gymLoader').hide();
 		var page = 0;
-		var teamSelector = ''; //''=all;0=neutral;1=Blue;2=Red;3=Yellow
+		var teamSelector = ''; //''=all;0=neutral; 1=Blue; 2=Red; 3=Yellow
 		var rankingFilter = 0; //0=Level & Gyms; 1=Level; 2=Gyms
 
 		$('input#name').filter(':visible').val(gymName);
-		loadGyms(page, $('input#name').filter(':visible').val(), null, null, pokeimg_suffix, true);
 
-		page++;
 		$('#loadMoreButton').click(function () {
 			loadGyms(page, $('input#name').filter(':visible').val(), teamSelector, rankingFilter, pokeimg_suffix, true);
 			page++;
-		});
-		$("#searchGyms").submit(function ( event ) {
+		}).trigger('click');
+
+		$('#searchGyms').submit(function ( event ) {
 			page = 0;
-			$('#gymsContainer tr:not(.gymsTemplate)').remove();
-			loadGyms(page, $('input#name').filter(':visible').val(), teamSelector, rankingFilter, pokeimg_suffix, true);
-			page++;
+			$('#gymsContainer').empty();
+			$('#loadMoreButton').trigger('click');
 			event.preventDefault();
 		});
-		$(".teamSelectorItems").click(function ( event ) {
-			switch ($(this).attr("id")) {
-				case "NeutralTeamsFilter":
+
+		$('.teamSelectorItems').click(function ( event ) {
+			switch ($(this).attr('id')) {
+				case 'NeutralTeamsFilter':
 					teamSelector=0;
 					break;
-				case "BlueTeamFilter":
+				case 'BlueTeamFilter':
 					teamSelector=1;
 					break;
-				case "RedTeamFilter":
+				case 'RedTeamFilter':
 					teamSelector=2;
 					break;
-				case "YellowFilter":
+				case 'YellowFilter':
 					teamSelector=3;
 					break;
 				default:
 					teamSelector='';
 			}
-			$("#teamSelectorText").html($(this).html());
+			$('#teamSelectorText').html($(this).html());
 			event.preventDefault();
-			$("#searchGyms").submit();
+			$('#searchGyms').submit();
 
 		});
-		$(".rankingOrderItems").click(function ( event ) {
-			switch ($(this).attr("id")) {
-				case "changedFirst":
+		$('.rankingOrderItems').click(function ( event ) {
+			switch ($(this).attr('id')) {
+				case 'changedFirst':
 					rankingFilter=0;
 					break;
-				case "nameFirst":
+				case 'nameFirst':
 					rankingFilter=1;
 					break;
-				case "prestigeFirst":
+				case 'prestigeFirst':
 					rankingFilter=2;
 					break;
 				default:
 					rankingFilter=0;
 			}
-			$("#rankingOrderText").html($(this).html());
+			$('#rankingOrderText').html($(this).html());
 			event.preventDefault();
-			$("#searchGyms").submit();
-
+			$('#searchGyms').submit();
 		});
 		window.onpopstate = function() {
-			if (window.history.state && "gym" === window.history.state.page) {
-				$('#gymsContainer').empty();
+			if (window.history.state && 'gymhistory' === window.history.state.page) {
 				$('input#name').filter(':visible').val(window.history.state.name);
-				loadGyms(0, $('input#name').filter(':visible').val(), teamSelector, rankingFilter, pokeimg_suffix, false);
+				page = 0;
+				$('#gymsContainer').empty();
+				$('#loadMoreButton').trigger('click');
 			} else {
 				window.history.back();
 			}
 		};
-
 	});
 });
 
 function loadGyms(page, name, teamSelector, rankingFilter, pokeimg_suffix, stayOnPage) {
 	$('.gymLoader').show();
-
 	if (stayOnPage) {
 		// build a state for this name
-		var state = {name: name, page: 'Gym History'};
-		window.history.pushState(state, 'Gym History', 'gymhistory?name=' + name);
+		var state = {name: name, page: 'gymhistory'};
+		window.history.pushState(state, 'gymhistory', 'gymhistory?name=' + name);
 	}
 	$.ajax({
 		'async': true,
-		'type': "GET",
+		'type': 'GET',
 		'global': false,
 		'dataType': 'json',
-		'url': "core/process/aru.php",
+		'url': 'core/process/aru.php',
 		'data': {
-			'request': '',
-			'target': 'arrange_url',
-			'method': 'method_target',
 			'type' : 'gyms',
 			'page' : page,
 			'name' : name,
@@ -125,8 +118,7 @@ function loadGyms(page, name, teamSelector, rankingFilter, pokeimg_suffix, stayO
 		if (internalIndex < 10) {
 			$('#loadMoreButton').hide();
 		} else {
-			$('#loadMoreButton').removeClass('hidden');
-			$('#loadMoreButton').show();
+			$('#loadMoreButton').removeClass('hidden').show();
 		}
 		$('.gymLoader').hide();
 	});
@@ -134,17 +126,13 @@ function loadGyms(page, name, teamSelector, rankingFilter, pokeimg_suffix, stayO
 
 function loadGymHistory(page, gym_id, pokeimg_suffix) {
 	$('.gymLoader').show();
-
 	$.ajax({
 		'async': true,
-		'type': "GET",
+		'type': 'GET',
 		'global': false,
 		'dataType': 'json',
-		'url': "core/process/aru.php",
+		'url': 'core/process/aru.php',
 		'data': {
-			'request': '',
-			'target': 'arrange_url',
-			'method': 'method_target',
 			'type' : 'gymhistory',
 			'page' : page,
 			'gym_id' : gym_id
@@ -159,8 +147,7 @@ function loadGymHistory(page, gym_id, pokeimg_suffix) {
 		if (internalIndex < 10) {
 			$('#gymHistory_'+gym_id).find('.loadMoreButtonHistory').hide();
 		} else {
-			$('#gymHistory_'+gym_id).find('.loadMoreButtonHistory').removeClass('hidden');
-			$('#gymHistory_'+gym_id).find('.loadMoreButtonHistory').data('page', page+1).show();
+			$('#gymHistory_'+gym_id).find('.loadMoreButtonHistory').removeClass('hidden').data('page', page+1).show();
 		}
 		$('.gymLoader').hide();
 	});

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -742,7 +742,7 @@ switch ($request) {
 			$result = $mysqli->query($req);
 			while ($result && $data = $result->fetch_object()) {
 				$pkm = array();
-				if ($data->gym_points == 0) $data->pokemon_uids = null;
+				if ($data->gym_points == 0) { $data->pokemon_uids = null; }
 				if ($data->pokemon_uids != null) {
 					$pkm_uids = explode(',', $data->pokemon_uids);
 					$pkm_req = "SELECT pokemon_uid, pokemon_id, cp, trainer_name
@@ -755,14 +755,9 @@ switch ($request) {
 					}
 				}
 				$data->pokemon = $pkm;
-				unset($data->pokemon_uids);
 				$data->gym_id = str_replace('.', '_', $data->gym_id);
 				$entries[] = $data;
 			}
-
-			$onlyPkmUid = function($p) {
-				return $p->pokemon_uid;
-			};
 
 			foreach ($entries as $idx => $entry) {
 				$entry->gym_points_diff = 0;
@@ -770,8 +765,8 @@ switch ($request) {
 					$next_entry = $entries[$idx+1];
 					$entry->gym_points_diff = $entry->gym_points - $next_entry->gym_points;
 					$entry->class = $entry->gym_points_diff > 0 ? 'gain' : ($entry->gym_points_diff < 0 ? 'loss' : '');
-					$entry_pokemon = array_map($onlyPkmUid, $entry->pokemon);
-					$next_entry_pokemon = array_map($onlyPkmUid, $next_entry->pokemon);
+					$entry_pokemon = explode(',', $entry->pokemon_uids_end);
+					$next_entry_pokemon = explode(',', $next_entry->pokemon_uids_end);
 					$new_pokemon = array_diff($entry_pokemon, $next_entry_pokemon);
 					$old_pokemon = array_diff($next_entry_pokemon, $entry_pokemon);
 					foreach ($new_pokemon as $pkm) {
@@ -781,6 +776,7 @@ switch ($request) {
 						$next_entry->pokemon[$pkm]->class = 'old';
 					}
 				}
+				unset($entry->pokemon_uids);
 			}
 		}
 

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -692,7 +692,7 @@ switch ($request) {
 		while ($result && $data = $result->fetch_object()) {
 			$pkm = array();
 			if ($data->gym_points > 0) {
-				$pkm_req = "SELECT gymmember.pokemon_uid, pokemon_id, cp, trainer_name
+				$pkm_req = "SELECT DISTINCT gymmember.pokemon_uid, pokemon_id, cp, trainer_name
 							FROM gymmember
 							LEFT JOIN gympokemon
 							ON gymmember.pokemon_uid = gympokemon.pokemon_uid
@@ -745,7 +745,7 @@ switch ($request) {
 				if ($data->gym_points == 0) { $data->pokemon_uids = ''; }
 				if ($data->pokemon_uids != '') {
 					$pkm_uids = explode(',', $data->pokemon_uids);
-					$pkm_req = "SELECT pokemon_uid, pokemon_id, cp, trainer_name
+					$pkm_req = "SELECT DISTINCT pokemon_uid, pokemon_id, cp, trainer_name
 								FROM gympokemon
 								WHERE pokemon_uid IN ('". implode("','", $pkm_uids) ."')
 								ORDER BY cp DESC";

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -737,7 +737,7 @@ switch ($request) {
 					FROM gymhistory
 					WHERE gym_id='".$gym_id."'
 					ORDER BY last_modified DESC
-					LIMIT ".($page * 10).",10";
+					LIMIT ".($page * 10).",11";
 
 			$result = $mysqli->query($req);
 			while ($result && $data = $result->fetch_object()) {
@@ -778,6 +778,8 @@ switch ($request) {
 				}
 				unset($entry->pokemon_uids);
 			}
+
+			if (count($entries) > 10) { array_pop($entries); }
 		}
 
 		$json = array();

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -765,8 +765,8 @@ switch ($request) {
 					$next_entry = $entries[$idx+1];
 					$entry->gym_points_diff = $entry->gym_points - $next_entry->gym_points;
 					$entry->class = $entry->gym_points_diff > 0 ? 'gain' : ($entry->gym_points_diff < 0 ? 'loss' : '');
-					$entry_pokemon = explode(',', $entry->pokemon_uids_end);
-					$next_entry_pokemon = explode(',', $next_entry->pokemon_uids_end);
+					$entry_pokemon = explode(',', $entry->pokemon_uids);
+					$next_entry_pokemon = explode(',', $next_entry->pokemon_uids);
 					$new_pokemon = array_diff($entry_pokemon, $next_entry_pokemon);
 					$old_pokemon = array_diff($next_entry_pokemon, $entry_pokemon);
 					foreach ($new_pokemon as $pkm) {

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -648,6 +648,153 @@ switch ($request) {
 		break;
 
 
+	case 'gyms':
+		$page = '0';
+		$where = '';
+		$order = '';
+		$ranking = 0;
+		if (isset($_GET['name']) && $_GET['name'] != '') {
+			$gym_name = mysqli_real_escape_string($mysqli, $_GET['name']);
+			$where = " WHERE name LIKE '%".$gym_name."%'";
+		}
+		if (isset($_GET['team']) && $_GET['team'] != '') {
+			$team = mysqli_real_escape_string($mysqli, $_GET['team']);
+			$where .= ($where == "" ? " WHERE" : " AND")." team_id = ".$team;
+		}
+		if (isset($_GET['page'])) {
+			$page = mysqli_real_escape_string($mysqli, $_GET['page']);
+		}
+		if (isset($_GET['ranking'])) {
+			$ranking = mysqli_real_escape_string($mysqli, $_GET['ranking']);
+		}
+
+		switch ($ranking) {
+			case 1:
+				$order = " ORDER BY name, last_modified DESC";
+				break;
+			case 2:
+				$order = " ORDER BY gym_points DESC, last_modified DESC";
+				break;
+			default:
+				$order = " ORDER BY last_modified DESC, name";
+		}
+
+		$limit = " LIMIT ".($page * 10).",10";
+
+		$req = "SELECT gymdetails.gym_id, name, team_id, gym_points, (CONVERT_TZ(last_modified, '+00:00', '".$time_offset."')) as last_modified
+				FROM gymdetails
+				LEFT JOIN gym
+				ON gymdetails.gym_id = gym.gym_id
+				".$where.$order.$limit;
+
+		$result = $mysqli->query($req);
+		$gyms = array();
+		while ($result && $data = $result->fetch_object()) {
+			$pkm = array();
+			if ($data->gym_points > 0) {
+				$pkm_req = "SELECT gymmember.pokemon_uid, pokemon_id, cp, trainer_name
+					FROM gymmember
+					LEFT JOIN gympokemon
+					ON gymmember.pokemon_uid = gympokemon.pokemon_uid
+					WHERE gymmember.gym_id = '". $data->gym_id ."'
+					ORDER BY cp DESC";
+				$pkm_result = $mysqli->query($pkm_req);
+				while ($pkm_result && $pkm_data = $pkm_result->fetch_object()) {
+					$pkm[] = $pkm_data;
+				}
+			}
+			$data->pokemon = $pkm;
+			unset($data->pokemon_uids);
+			$data->gym_id = str_replace('.', '_', $data->gym_id);
+			$gyms[] = $data;
+		}
+		$json = array();
+		$json['gyms'] = $gyms;
+		$locale = array();
+		$json['locale'] = $locale;
+
+		header('Content-Type: application/json');
+		echo json_encode($json);
+
+		break;
+
+
+	case 'gymhistory':
+		$gym_id = '';
+		$page = '0';
+		if (isset($_GET['gym_id'])) {
+			$gym_id = mysqli_real_escape_string($mysqli, $_GET['gym_id']);
+			$gym_id = str_replace('_', '.', $gym_id);
+		}
+		if (isset($_GET['page'])) {
+			$page = mysqli_real_escape_string($mysqli, $_GET['page']);
+		}
+
+		$entries = array();
+
+		if ($gym_id != '') {
+			$req = "SELECT gym_id, team_id, gym_points, pokemon_uids, (CONVERT_TZ(last_modified, '+00:00', '".$time_offset."')) as last_modified
+					FROM gymhistory
+					WHERE gym_id='".$gym_id."'
+					ORDER BY last_modified DESC
+					LIMIT ".($page * 10).",10";
+
+			$result = $mysqli->query($req);
+			while ($result && $data = $result->fetch_object()) {
+				$pkm = array();
+				if ($data->gym_points == 0) $data->pokemon_uids = null;
+				if ($data->pokemon_uids != null) {
+					$pkm_uids = explode(',', $data->pokemon_uids);
+					$pkm_req = "SELECT pokemon_uid, pokemon_id, cp, trainer_name
+						FROM gympokemon
+						WHERE pokemon_uid IN ('". implode("','", $pkm_uids) ."')
+						ORDER BY cp DESC";
+					$pkm_result = $mysqli->query($pkm_req);
+					while ($pkm_result && $pkm_data = $pkm_result->fetch_object()) {
+						$pkm[$pkm_data->pokemon_uid] = $pkm_data;
+					}
+				}
+				$data->pokemon = $pkm;
+				unset($data->pokemon_uids);
+				$data->gym_id = str_replace('.', '_', $data->gym_id);
+				$entries[] = $data;
+			}
+
+			$onlyPkmUid = function($p) {
+				return $p->pokemon_uid;
+			};
+
+			foreach ($entries as $idx => $entry) {
+				$entry->gym_points_diff = 0;
+				if ($idx < count($entries) - 1) {
+					$next_entry = $entries[$idx+1];
+					$entry->gym_points_diff = $entry->gym_points - $next_entry->gym_points;
+					$entry->class = $entry->gym_points_diff > 0 ? 'gain' : ($entry->gym_points_diff < 0 ? 'loss' : '');
+					$entry_pokemon = array_map($onlyPkmUid, $entry->pokemon);
+					$next_entry_pokemon = array_map($onlyPkmUid, $next_entry->pokemon);
+					$new_pokemon = array_diff($entry_pokemon, $next_entry_pokemon);
+					$old_pokemon = array_diff($next_entry_pokemon, $entry_pokemon);
+					foreach ($new_pokemon as $pkm) {
+						$entry->pokemon[$pkm]->class = 'new';
+					}
+					foreach ($old_pokemon as $pkm) {
+						$next_entry->pokemon[$pkm]->class = 'old';
+					}
+				}
+			}
+		}
+
+		$json = array();
+		$json['entries'] = $entries;
+		$locale = array();
+		$json['locale'] = $locale;
+
+		header('Content-Type: application/json');
+		echo json_encode($json);
+
+		break;
+
+
 	case 'pokemon_slider_init':
 		$req 		= "SELECT MIN(disappear_time) AS min, MAX(disappear_time) AS max FROM pokemon";
 		$result 	= $mysqli->query($req);

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -693,11 +693,11 @@ switch ($request) {
 			$pkm = array();
 			if ($data->gym_points > 0) {
 				$pkm_req = "SELECT gymmember.pokemon_uid, pokemon_id, cp, trainer_name
-					FROM gymmember
-					LEFT JOIN gympokemon
-					ON gymmember.pokemon_uid = gympokemon.pokemon_uid
-					WHERE gymmember.gym_id = '". $data->gym_id ."'
-					ORDER BY cp DESC";
+							FROM gymmember
+							LEFT JOIN gympokemon
+							ON gymmember.pokemon_uid = gympokemon.pokemon_uid
+							WHERE gymmember.gym_id = '". $data->gym_id ."'
+							ORDER BY cp DESC";
 				$pkm_result = $mysqli->query($pkm_req);
 				while ($pkm_result && $pkm_data = $pkm_result->fetch_object()) {
 					$pkm[] = $pkm_data;
@@ -742,13 +742,13 @@ switch ($request) {
 			$result = $mysqli->query($req);
 			while ($result && $data = $result->fetch_object()) {
 				$pkm = array();
-				if ($data->gym_points == 0) { $data->pokemon_uids = null; }
-				if ($data->pokemon_uids != null) {
+				if ($data->gym_points == 0) { $data->pokemon_uids = ''; }
+				if ($data->pokemon_uids != '') {
 					$pkm_uids = explode(',', $data->pokemon_uids);
 					$pkm_req = "SELECT pokemon_uid, pokemon_id, cp, trainer_name
-						FROM gympokemon
-						WHERE pokemon_uid IN ('". implode("','", $pkm_uids) ."')
-						ORDER BY cp DESC";
+								FROM gympokemon
+								WHERE pokemon_uid IN ('". implode("','", $pkm_uids) ."')
+								ORDER BY cp DESC";
 					$pkm_result = $mysqli->query($pkm_req);
 					while ($pkm_result && $pkm_data = $pkm_result->fetch_object()) {
 						$pkm[$pkm_data->pokemon_uid] = $pkm_data;
@@ -765,8 +765,8 @@ switch ($request) {
 					$next_entry = $entries[$idx+1];
 					$entry->gym_points_diff = $entry->gym_points - $next_entry->gym_points;
 					$entry->class = $entry->gym_points_diff > 0 ? 'gain' : ($entry->gym_points_diff < 0 ? 'loss' : '');
-					$entry_pokemon = explode(',', $entry->pokemon_uids);
-					$next_entry_pokemon = explode(',', $next_entry->pokemon_uids);
+					$entry_pokemon = preg_split('/,/', $entry->pokemon_uids, null, PREG_SPLIT_NO_EMPTY);
+					$next_entry_pokemon = preg_split('/,/', $next_entry->pokemon_uids, null, PREG_SPLIT_NO_EMPTY);
 					$new_pokemon = array_diff($entry_pokemon, $next_entry_pokemon);
 					$old_pokemon = array_diff($next_entry_pokemon, $entry_pokemon);
 					foreach ($new_pokemon as $pkm) {

--- a/htaccess
+++ b/htaccess
@@ -29,6 +29,7 @@ RewriteRule ^dashboard$			index.php?page=dashboard		[QSA,NC,L]
 RewriteRule ^pokemon/$			index.php?page=pokedex			[QSA,NC,L]
 RewriteRule ^pokemon$			index.php?page=pokedex			[QSA,NC,L]
 RewriteRule ^nests$			index.php?page=nests			[QSA,NC,L]
+RewriteRule ^gymhistory$		index.php?page=gymhistory		[QSA,NC,L]
 
 
 # Cache static files for one month

--- a/index.php
+++ b/index.php
@@ -252,6 +252,14 @@ include_once('core/process/data.loader.php');
 
 					<?php
 					break;
+
+				case 'gymhistory':
+					?>
+
+					<script src="<?php auto_ver('core/js/gymhistory.content.js') ?>"></script>
+
+					<?php
+					break;
 			}
 		}
 		?>

--- a/pages/gymhistory.page.php
+++ b/pages/gymhistory.page.php
@@ -1,0 +1,76 @@
+<header id="single-header">
+<div class="row">
+	<div class="col-md-12 text-center">
+		<h1>Explore our <strong>Gym History</strong><br><small>Teams, levels, prestige and Pokémons of gyms</small></h1>
+	</div>
+</div>
+<div class="row">
+	<div class="col-md-12 text-center">
+		<form class="form-inline" id="searchGyms" method="GET">
+		  <div class="form-group">
+			<div class="input-group">
+				<div class="input-group-btn">
+					<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="teamSelector"><span id="teamSelectorText"><?= $locales->TRAINERS_SEARCH_ALL_TEAMS ?></span>&nbsp;<span class="caret"></span></button>
+					<ul class="dropdown-menu">
+						<li><a class="teamSelectorItems" id="AllTeamsFilter" href="#"><?= $locales->TRAINERS_SEARCH_ALL_TEAMS ?></a></li>
+						<li><a class="teamSelectorItems" id="NeutralTeamsFilter" href="#"><img src="core/img/map_white.png" />&nbsp;Neutral</a></li>
+						<li><a class="teamSelectorItems" id="BlueTeamFilter" href="#"><img src="core/img/map_blue.png" />&nbsp;<?= $locales->MYSTIC ?></a></li>
+						<li><a class="teamSelectorItems" id="RedTeamFilter" href="#"><img src="core/img/map_red.png" />&nbsp;<?= $locales->VALOR ?></a></li>
+						<li><a class="teamSelectorItems" id="YellowFilter" href="#"><img src="core/img/map_yellow.png" />&nbsp;<?= $locales->INSTINCT ?></a></li>
+					</ul>
+				</div>
+				<input type="text" class="form-control" name="name" id="name" placeholder="Gym name" value="">
+				<div class="input-group-btn">
+					<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"  id="rankingSelector"><span id="rankingOrderText">by last changed</span>&nbsp;<span class="caret"></span></button>
+					<ul class="dropdown-menu dropdown-menu-right">
+					  <li><a class="rankingOrderItems" id="changedFirst" href="#">&nbsp;by last changed</a></li>
+					  <li><a class="rankingOrderItems" id="nameFirst" href="#">&nbsp;by name</a></li>
+					  <li><a class="rankingOrderItems" id="prestigeFirst" href="#">&nbsp;by prestige</a></li>
+					</ul>
+				</div>
+			</div>
+		  </div>
+		  <button type="submit" class="btn btn-primary"><?= $locales->SEARCH ?></button>
+		</form>
+	</div>
+</div>
+</header>
+
+<div class="row">
+	<div class="col-md-12">
+		<div class="text-center">
+			<h3>Recent Gym Activity</h3>
+		</div>
+		<table class="table" id="gymsTable">
+			<thead>
+				<tr>
+					<th>Time</th>
+					<th>Gym</th>
+					<th>Level</th>
+					<th>Prestige</th>
+					<th>Pokémon</th>
+				</tr>
+			</thead>
+			<tbody id="gymsContainer">
+
+			</tbody>
+			<tfoot>
+				<tr class="loadMore text-center">
+					<td colspan="7"><button id="loadMoreButton" class="btn btn-default hidden"><?= $locales->TRAINERS_LOAD_MORE ?></button></td>
+				</tr>
+				<tr class="gymLoader">
+					<td colspan="7"><div class="loader"></div></td>
+				</tr>
+			</tfoot>
+		</table>
+	</div>
+</div>
+<script type="text/javascript">
+<?=
+$gymName = "";
+if (isset($_GET['name']) && $_GET['name']!="") {
+	$gymName = htmlentities($_GET['name']);
+}
+?>
+var gymName = "<?= $gymName ?>";
+</script>

--- a/pages/gymhistory.page.php
+++ b/pages/gymhistory.page.php
@@ -41,7 +41,7 @@
 		<div class="text-center">
 			<h3>Recent Gym Activity</h3>
 		</div>
-		<table class="table" id="gymsTable">
+		<table class="table table-hover" id="gymsTable">
 			<thead>
 				<tr>
 					<th>Time</th>

--- a/readme.gymhistory.md
+++ b/readme.gymhistory.md
@@ -1,0 +1,62 @@
+Use the following SQL-Statements to create the new table:
+=========================================================
+
+--
+-- Table structure for table `gymhistory`
+--
+
+CREATE TABLE `gymhistory` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `gym_id` varchar(50) COLLATE utf8_unicode_ci NOT NULL,
+  `team_id` smallint(6) NOT NULL,
+  `guard_pokemon_id` smallint(6) NOT NULL,
+  `gym_points` int(11) NOT NULL DEFAULT '0',
+  `last_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `last_updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `pokemon_uids` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+--
+-- Indexes for table `gymhistory`
+--
+ALTER TABLE `gymhistory`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `gym_id` (`gym_id`),
+  ADD KEY `gym_points` (`gym_points`),
+  ADD KEY `last_modified` (`last_modified`),
+  ADD KEY `team_id` (`team_id`),
+  ADD KEY `last_updated` (`last_updated`);
+
+--
+-- Add inital dataset for table `gymhistory`
+--
+INSERT INTO gymhistory
+  (
+    SELECT NULL, g.gym_id, g.team_id, g.guard_pokemon_id, g.gym_points, g.last_modified, g.last_modified as last_updated,
+    (
+      SELECT GROUP_CONCAT(DISTINCT pokemon_uid SEPARATOR ',')
+      FROM gymmember AS gm
+      WHERE gm.gym_id = g.gym_id GROUP BY gym_id
+    ) AS pokemon_uids
+  )
+  FROM gym AS g;
+
+
+Use the following SQL-Statements to create the event to update the new table:
+=============================================================================
+
+--
+-- Create event `gymhistory_update`
+--
+CREATE EVENT `gymhistory_update`
+ON SCHEDULE EVERY 20 SECOND
+DO BEGIN
+  INSERT INTO gymhistory (SELECT NULL, g.gym_id, g.team_id, g.guard_pokemon_id, g.gym_points, g.last_modified, g.last_modified as last_updated, (SELECT GROUP_CONCAT(DISTINCT pokemon_uid SEPARATOR ',') FROM gymmember AS gm WHERE gm.gym_id = g.gym_id GROUP BY gym_id) AS pokemon_uids FROM gym AS g WHERE g.last_modified > (SELECT MAX(last_modified) FROM gymhistory));
+  UPDATE gymhistory AS gh
+  JOIN (SELECT gym_id, MAX(last_modified) as last_modified FROM gymhistory GROUP BY gym_id)
+  AS gg ON gh.gym_id = gg.gym_id AND gh.last_modified = gg.last_modified
+  JOIN (SELECT gym_id, last_scanned, GROUP_CONCAT(DISTINCT pokemon_uid SEPARATOR ',') AS pokemon_uids FROM gymmember AS gm GROUP BY gym_id)
+  AS gm ON gh.gym_id = gm.gym_id
+  SET gh.last_updated = gm.last_scanned, gh.pokemon_uids = gm.pokemon_uids
+  WHERE gh.last_updated < gm.last_scanned;
+END

--- a/readme.gymhistory.md
+++ b/readme.gymhistory.md
@@ -13,24 +13,19 @@ CREATE TABLE `gymhistory` (
   `gym_points` int(11) NOT NULL DEFAULT '0',
   `last_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `last_updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `pokemon_uids` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL
+  `pokemon_uids` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `gym_id` (`gym_id`),
+  KEY `gym_points` (`gym_points`),
+  KEY `last_modified` (`last_modified`),
+  KEY `team_id` (`team_id`),
+  KEY `last_updated` (`last_updated`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
-
---
--- Indexes for table `gymhistory`
---
-ALTER TABLE `gymhistory`
-  ADD PRIMARY KEY (`id`),
-  ADD KEY `gym_id` (`gym_id`),
-  ADD KEY `gym_points` (`gym_points`),
-  ADD KEY `last_modified` (`last_modified`),
-  ADD KEY `team_id` (`team_id`),
-  ADD KEY `last_updated` (`last_updated`);
 
 --
 -- Add inital dataset for table `gymhistory`
 --
-INSERT INTO gymhistory
+INSERT INTO `gymhistory`
   (
     SELECT NULL, g.gym_id, g.team_id, g.guard_pokemon_id, g.gym_points, g.last_modified, g.last_modified as last_updated,
     (
@@ -60,3 +55,8 @@ DO BEGIN
   SET gh.last_updated = gm.last_scanned, gh.pokemon_uids = gm.pokemon_uids
   WHERE gh.last_updated < gm.last_scanned;
 END
+
+--
+-- Enable MySQL event scheduler
+--
+SET GLOBAL event_scheduler = ON;

--- a/readme.gymhistory.md
+++ b/readme.gymhistory.md
@@ -13,27 +13,25 @@ CREATE TABLE IF NOT EXISTS `gymhistory` (
   `last_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `last_updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `pokemon_uids` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `pokemon_count` smallint(6) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `gym_id` (`gym_id`),
+  KEY `team_id` (`team_id`),
   KEY `gym_points` (`gym_points`),
   KEY `last_modified` (`last_modified`),
-  KEY `team_id` (`team_id`),
-  KEY `last_updated` (`last_updated`)
+  KEY `last_updated` (`last_updated`),
+  KEY `combined` (`gym_id`, `team_id`, `gym_points`, `last_updated`, `pokemon_count`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --
 -- Add inital dataset for table `gymhistory`
 --
-INSERT INTO `gymhistory`
-  (
-    SELECT NULL, g.gym_id, g.team_id, g.guard_pokemon_id, g.gym_points, g.last_modified, g.last_modified as last_updated,
-    (
-      SELECT GROUP_CONCAT(DISTINCT pokemon_uid SEPARATOR ',')
-      FROM gymmember AS gm
-      WHERE gm.gym_id = g.gym_id GROUP BY gym_id
-    ) AS pokemon_uids
-    FROM gym AS g
-  );
+INSERT INTO `gymhistory` (
+  SELECT NULL, g.gym_id, g.team_id, g.guard_pokemon_id, g.gym_points, g.last_modified, g.last_modified as last_updated,
+  (SELECT GROUP_CONCAT(DISTINCT pokemon_uid SEPARATOR ',') FROM gymmember AS gm WHERE gm.gym_id = g.gym_id GROUP BY gym_id) AS pokemon_uids,
+  (SELECT COUNT(DISTINCT pokemon_uid) FROM gymmember AS gm WHERE gm.gym_id = g.gym_id) AS pokemon_count
+  FROM gym AS g
+);
 
 
 Use the following SQL-Statements to create the event to update the new table:
@@ -44,15 +42,15 @@ Use the following SQL-Statements to create the event to update the new table:
 --
 DELIMITER //
 CREATE EVENT IF NOT EXISTS `gymhistory_update`
-ON SCHEDULE EVERY 20 SECOND
+ON SCHEDULE EVERY 15 SECOND
 DO BEGIN
-  INSERT INTO gymhistory (SELECT NULL, g.gym_id, g.team_id, g.guard_pokemon_id, g.gym_points, g.last_modified, g.last_modified as last_updated, (SELECT GROUP_CONCAT(DISTINCT pokemon_uid SEPARATOR ',') FROM gymmember AS gm WHERE gm.gym_id = g.gym_id GROUP BY gym_id) AS pokemon_uids FROM gym AS g WHERE g.last_modified > (SELECT MAX(last_modified) FROM gymhistory));
+  INSERT INTO gymhistory (SELECT NULL, g.gym_id, g.team_id, g.guard_pokemon_id, g.gym_points, g.last_modified, g.last_modified as last_updated, (SELECT GROUP_CONCAT(DISTINCT pokemon_uid SEPARATOR ',') FROM gymmember AS gm WHERE gm.gym_id = g.gym_id GROUP BY gym_id) AS pokemon_uids, (SELECT COUNT(DISTINCT pokemon_uid) FROM gymmember AS gm WHERE gm.gym_id = g.gym_id) AS pokemon_count FROM gym AS g WHERE g.last_modified > (SELECT MAX(last_modified) FROM gymhistory));
   UPDATE gymhistory AS gh
   JOIN (SELECT gym_id, MAX(last_modified) as max_last_modified FROM gymhistory GROUP BY gym_id)
   AS gg ON gh.gym_id = gg.gym_id AND gh.last_modified = gg.max_last_modified
-  JOIN (SELECT gym_id, last_scanned, GROUP_CONCAT(DISTINCT pokemon_uid SEPARATOR ',') AS pokemon_uids FROM gymmember AS gm GROUP BY gym_id)
+  JOIN (SELECT gym_id, last_scanned, GROUP_CONCAT(DISTINCT pokemon_uid SEPARATOR ',') AS pokemon_uids, COUNT(DISTINCT pokemon_uid) as pokemon_count FROM gymmember AS gm GROUP BY gym_id)
   AS gm ON gh.gym_id = gm.gym_id
-  SET gh.last_updated = gm.last_scanned, gh.pokemon_uids = gm.pokemon_uids
+  SET gh.last_updated = gm.last_scanned, gh.pokemon_uids = gm.pokemon_uids, gh.pokemon_count = gm.pokemon_count
   WHERE gh.last_updated < gm.last_scanned;
 END
 //

--- a/readme.gymhistory.md
+++ b/readme.gymhistory.md
@@ -38,8 +38,8 @@ INSERT INTO gymhistory
       FROM gymmember AS gm
       WHERE gm.gym_id = g.gym_id GROUP BY gym_id
     ) AS pokemon_uids
-  )
-  FROM gym AS g;
+    FROM gym AS g
+  );
 
 
 Use the following SQL-Statements to create the event to update the new table:

--- a/readme.gymhistory.md
+++ b/readme.gymhistory.md
@@ -42,20 +42,21 @@ Use the following SQL-Statements to create the event to update the new table:
 --
 -- Create event `gymhistory_update`
 --
-delimiter $$
+DELIMITER //
 CREATE EVENT IF NOT EXISTS `gymhistory_update`
-  ON SCHEDULE EVERY 20 SECOND
-  DO BEGIN
-    INSERT INTO gymhistory (SELECT NULL, g.gym_id, g.team_id, g.guard_pokemon_id, g.gym_points, g.last_modified, g.last_modified as last_updated, (SELECT GROUP_CONCAT(DISTINCT pokemon_uid SEPARATOR ',') FROM gymmember AS gm WHERE gm.gym_id = g.gym_id GROUP BY gym_id) AS pokemon_uids FROM gym AS g WHERE g.last_modified > (SELECT MAX(last_modified) FROM gymhistory));
-    UPDATE gymhistory AS gh
-    JOIN (SELECT gym_id, MAX(last_modified) as max_last_modified FROM gymhistory GROUP BY gym_id)
-    AS gg ON gh.gym_id = gg.gym_id AND gh.last_modified = gg.max_last_modified
-    JOIN (SELECT gym_id, last_scanned, GROUP_CONCAT(DISTINCT pokemon_uid SEPARATOR ',') AS pokemon_uids FROM gymmember AS gm GROUP BY gym_id)
-    AS gm ON gh.gym_id = gm.gym_id
-    SET gh.last_updated = gm.last_scanned, gh.pokemon_uids = gm.pokemon_uids
-    WHERE gh.last_updated < gm.last_scanned;
-  END$$
-delimiter ;
+ON SCHEDULE EVERY 20 SECOND
+DO BEGIN
+  INSERT INTO gymhistory (SELECT NULL, g.gym_id, g.team_id, g.guard_pokemon_id, g.gym_points, g.last_modified, g.last_modified as last_updated, (SELECT GROUP_CONCAT(DISTINCT pokemon_uid SEPARATOR ',') FROM gymmember AS gm WHERE gm.gym_id = g.gym_id GROUP BY gym_id) AS pokemon_uids FROM gym AS g WHERE g.last_modified > (SELECT MAX(last_modified) FROM gymhistory));
+  UPDATE gymhistory AS gh
+  JOIN (SELECT gym_id, MAX(last_modified) as max_last_modified FROM gymhistory GROUP BY gym_id)
+  AS gg ON gh.gym_id = gg.gym_id AND gh.last_modified = gg.max_last_modified
+  JOIN (SELECT gym_id, last_scanned, GROUP_CONCAT(DISTINCT pokemon_uid SEPARATOR ',') AS pokemon_uids FROM gymmember AS gm GROUP BY gym_id)
+  AS gm ON gh.gym_id = gm.gym_id
+  SET gh.last_updated = gm.last_scanned, gh.pokemon_uids = gm.pokemon_uids
+  WHERE gh.last_updated < gm.last_scanned;
+END
+//
+DELIMITER ;
 
 --
 -- Enable MySQL event scheduler

--- a/readme.gymhistory.md
+++ b/readme.gymhistory.md
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS `gymhistory` (
   KEY `last_modified` (`last_modified`),
   KEY `team_id` (`team_id`),
   KEY `last_updated` (`last_updated`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --
 -- Add inital dataset for table `gymhistory`

--- a/readme.gymhistory.md
+++ b/readme.gymhistory.md
@@ -6,20 +6,20 @@ Use the following SQL-Statements to create the new table:
 --
 CREATE TABLE IF NOT EXISTS `gymhistory` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `gym_id` varchar(50) COLLATE utf8_unicode_ci NOT NULL,
+  `gym_id` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,
   `team_id` smallint(6) NOT NULL,
   `guard_pokemon_id` smallint(6) NOT NULL,
   `gym_points` int(11) NOT NULL DEFAULT '0',
   `last_modified` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `last_updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `pokemon_uids` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `pokemon_uids` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `gym_id` (`gym_id`),
   KEY `gym_points` (`gym_points`),
   KEY `last_modified` (`last_modified`),
   KEY `team_id` (`team_id`),
   KEY `last_updated` (`last_updated`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8mb4_unicode_ci;
 
 --
 -- Add inital dataset for table `gymhistory`

--- a/readme.gymhistory.md
+++ b/readme.gymhistory.md
@@ -4,8 +4,7 @@ Use the following SQL-Statements to create the new table:
 --
 -- Table structure for table `gymhistory`
 --
-
-CREATE TABLE `gymhistory` (
+CREATE TABLE IF NOT EXISTS `gymhistory` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `gym_id` varchar(50) COLLATE utf8_unicode_ci NOT NULL,
   `team_id` smallint(6) NOT NULL,
@@ -43,18 +42,20 @@ Use the following SQL-Statements to create the event to update the new table:
 --
 -- Create event `gymhistory_update`
 --
-CREATE EVENT `gymhistory_update`
-ON SCHEDULE EVERY 20 SECOND
-DO BEGIN
-  INSERT INTO gymhistory (SELECT NULL, g.gym_id, g.team_id, g.guard_pokemon_id, g.gym_points, g.last_modified, g.last_modified as last_updated, (SELECT GROUP_CONCAT(DISTINCT pokemon_uid SEPARATOR ',') FROM gymmember AS gm WHERE gm.gym_id = g.gym_id GROUP BY gym_id) AS pokemon_uids FROM gym AS g WHERE g.last_modified > (SELECT MAX(last_modified) FROM gymhistory));
-  UPDATE gymhistory AS gh
-  JOIN (SELECT gym_id, MAX(last_modified) as last_modified FROM gymhistory GROUP BY gym_id)
-  AS gg ON gh.gym_id = gg.gym_id AND gh.last_modified = gg.last_modified
-  JOIN (SELECT gym_id, last_scanned, GROUP_CONCAT(DISTINCT pokemon_uid SEPARATOR ',') AS pokemon_uids FROM gymmember AS gm GROUP BY gym_id)
-  AS gm ON gh.gym_id = gm.gym_id
-  SET gh.last_updated = gm.last_scanned, gh.pokemon_uids = gm.pokemon_uids
-  WHERE gh.last_updated < gm.last_scanned;
-END
+delimiter $$
+CREATE EVENT IF NOT EXISTS `gymhistory_update`
+  ON SCHEDULE EVERY 20 SECOND
+  DO BEGIN
+    INSERT INTO gymhistory (SELECT NULL, g.gym_id, g.team_id, g.guard_pokemon_id, g.gym_points, g.last_modified, g.last_modified as last_updated, (SELECT GROUP_CONCAT(DISTINCT pokemon_uid SEPARATOR ',') FROM gymmember AS gm WHERE gm.gym_id = g.gym_id GROUP BY gym_id) AS pokemon_uids FROM gym AS g WHERE g.last_modified > (SELECT MAX(last_modified) FROM gymhistory));
+    UPDATE gymhistory AS gh
+    JOIN (SELECT gym_id, MAX(last_modified) as max_last_modified FROM gymhistory GROUP BY gym_id)
+    AS gg ON gh.gym_id = gg.gym_id AND gh.last_modified = gg.max_last_modified
+    JOIN (SELECT gym_id, last_scanned, GROUP_CONCAT(DISTINCT pokemon_uid SEPARATOR ',') AS pokemon_uids FROM gymmember AS gm GROUP BY gym_id)
+    AS gm ON gh.gym_id = gm.gym_id
+    SET gh.last_updated = gm.last_scanned, gh.pokemon_uids = gm.pokemon_uids
+    WHERE gh.last_updated < gm.last_scanned;
+  END$$
+delimiter ;
 
 --
 -- Enable MySQL event scheduler


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Since I was always curious of what is happening in the gyms in my town, but no historical data is tracked by RocketMap, I have added a new SQL table that does so.
Using the MySQL scheduler, every 20secs the data from the "gym" table is added to the new "gym_history" one.
This data is then nicely represented on a separate new page. /gymhistory
The data is searchable, sortable and filterable.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Now you are able to see, when gyms are leveled up or down and which Pokémon are placed in or thrown out.
(This will also show you all those losers, who are using multiple accounts to shave their spot into high level gyms. There is a separate branch that extracts such behavior.)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in my own Worldopole online instance.
Does not interfere with any other functionality.

It is necessary to execute some SQL statements that I have documented in readme.gymhistory.md to create the new table and the update events.
Furthermore, you have to enable the MySQL event scheduler. This is also documented in the readme for a running server, but you should also update your server configuration to enable the scheduler on start.

Remark: it does not include any localization so far -> english only

## Screenshots (if appropriate):
![bildschirmfoto 2017-05-08 um 12 37 48](https://cloud.githubusercontent.com/assets/727517/25800855/4c877a4a-33eb-11e7-9fee-39ae6b945142.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## TODO
- [ ] Localization