### PR TITLE
Very small nests fixes (Add minute format and disableAutoPan)

### DIFF
--- a/core/cron/nests.cron.php
+++ b/core/cron/nests.cron.php
@@ -31,8 +31,8 @@ while ($data = $result->fetch_object()) {
 	if ($starttime < 0) {
 		$starttime = 3600 + $starttime;
 	}
-	$nests['st'] = floor($starttime / 60);
-	$nests['et'] = floor($data->latest_seen / 60);
+	$nests['st'] = sprintf('%02d', floor($starttime / 60));
+	$nests['et'] = sprintf('%02d', floor($data->latest_seen / 60));
 
 	// Add the data to array
 	$nestsdatas[] = $nests;

--- a/core/js/nests.maps.js.php
+++ b/core/js/nests.maps.js.php
@@ -89,7 +89,7 @@ function initMap() {
 			}
 		});
 
-		var infoWindow = new google.maps.InfoWindow({pixelOffset: new google.maps.Size(0, 8)});
+		var infoWindow = new google.maps.InfoWindow({pixelOffset: new google.maps.Size(0, 8), disableAutoPan: true});
 
 		// load data
 		$.getJSON("core/json/nests.stats.json", function(nestData) {


### PR DESCRIPTION
## Description
Very small fix for nests page:
- Display minutes in xx format like "01 to 31" or "35 to 05"
- Add disableAutoPan to stop the map jumping around while mouseover a Pokemon

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

