### PR TITLE
Fixed RAID locale in menu

### DIFF
--- a/core/json/variables.examples.json
+++ b/core/json/variables.examples.json
@@ -52,7 +52,7 @@
 		{
 			"type"		:	"link",
 			"href"		:	"raids",
-			"locale"	:	"RAID",
+			"locale"	:	"RAIDS",
 			"icon"		:	"fa-bolt"
 		},
 		{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Current locale for Raids in var.example does not match the english locale, so even adding it it does not show the text.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Local instance 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
