### PR TITLE
Make gym location url on raids page configurable

### DIFF
--- a/core/js/raids.content.js
+++ b/core/js/raids.content.js
@@ -13,7 +13,7 @@ $(function () {
 	});
 });
 
-function loadRaids(page, pokeimg_suffix) {
+function loadRaids(page, pokeimg_suffix, location_url) {
 	$('.raidsLoader').show();
 	$.ajax({
 		'type': 'GET',
@@ -27,7 +27,7 @@ function loadRaids(page, pokeimg_suffix) {
 		var internalIndex = 0;
 		$.each(data.raids, function (gym_id, raid) {
 			internalIndex++;
-			printRaid(raid, pokeimg_suffix);
+			printRaid(raid, pokeimg_suffix, location_url);
 		});
 		if(internalIndex < 10){
 			$('#loadMoreButton').hide();

--- a/core/js/raids.content.js
+++ b/core/js/raids.content.js
@@ -1,12 +1,13 @@
 $(function () {
 	$.getJSON( "core/json/variables.json", function(variables) {
 		var pokeimg_suffix = variables['system']['pokeimg_suffix'];
+		var location_url = variables['system']['location_url'] || 'https://maps.google.com/?q={latitude},{longitude}&ll={latitude},{longitude}&z=16';
 		$('.raidsLoader').hide();
 		var page = 0;
-		loadRaids(page, pokeimg_suffix);
+		loadRaids(page, pokeimg_suffix, location_url);
 		page++;
 		$('#loadMoreButton').click(function () {
-			loadRaids(page, pokeimg_suffix);
+			loadRaids(page, pokeimg_suffix, location_url);
 			page++;
 		});
 	});
@@ -39,7 +40,7 @@ function loadRaids(page, pokeimg_suffix) {
 	});
 };
 
-function printRaid(raid, pokeimg_suffix) {
+function printRaid(raid, pokeimg_suffix, location_url) {
 	var now = new Date();
 	var raidStart = new Date(raid.start);
 	var raidEnd = new Date(raid.end);
@@ -48,7 +49,9 @@ function printRaid(raid, pokeimg_suffix) {
 	raidInfos.append($('<td>',{id: 'raidLevel_'+raid.gym_id, text: '★'.repeat(raid.level)}));
 	raidInfos.append($('<td>',{id: 'raidTime_'+raid.gym_id, text: raid.starttime + ' - ' + raid.endtime}));
 	raidInfos.append($('<td>',{id: 'raidRemaining_'+raid.gym_id, class: 'pokemon-remaining'}).append($('<span>',{class: (raidStart < now ? 'current' : 'upcoming')})));
-	raidInfos.append($('<td>',{id: 'raidGym_'+raid.gym_id}).append($('<a>',{href: '/map/?lat=' + raid.latitude + '&lon=' + raid.longitude, text: raid.name})));
+
+	var locationLink = location_url.replace(/\{latitude\}/g, raid.latitude).replace(/\{longitude\}/g, raid.longitude)
+	raidInfos.append($('<td>',{id: 'raidGym_'+raid.gym_id}).append($('<a>',{href: locationLink, text: raid.name})));
 
 	var details = '';
 	var raidPokemon = $('<div>',{class: 'pokemon-single'});

--- a/core/json/variables.examples.json
+++ b/core/json/variables.examples.json
@@ -34,8 +34,9 @@
 		"captcha_support"		:	false,
 		"iv_numbers"			:	false,
 		"forced_lang"			:	"",
-		"default_lang"			:	"en"
-	},	
+		"default_lang"			:	"en",
+		"location_url"			:	"/map/?lat={latitude}&lon={longitude}"
+	},
 	"menu":[
 		{
 			"type"		:	"link",
@@ -85,6 +86,5 @@
 			"text"		:	"Twitter",
 			"icon"		:	"fa-twitter"
 		}
-		
 	]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use a new entry from variables.json to provide a configurable url for gym location.
`"location_url" : "/map/?lat={latitude}&lon={longitude}"`
If none is specified, a google maps url is used.

This variable could later also used in other places, like the home page.

## Motivation and Context
Each RM URL can be different but is currently hardcoded.
Fixes #297 #298 

## How Has This Been Tested?
Tested on own instance.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
