### PR TITLE
Fix counter showing NaN in Safari

### DIFF
--- a/core/js/raids.content.js
+++ b/core/js/raids.content.js
@@ -41,8 +41,8 @@ function loadRaids(page, pokeimg_suffix) {
 
 function printRaid(raid, pokeimg_suffix) {
 	var now = new Date();
-	var raidStart = new Date(raid.start);
-	var raidEnd = new Date(raid.end);
+	var raidStart = new Date(raid.start.replace(/-/g, '/'));
+	var raidEnd = new Date(raid.end.replace(/-/g, '/'));
 
 	var raidInfos = $('<tr>',{id: 'raidInfos_'+raid.gym_id}).css('border-bottom','2px solid '+(raid.level>2?'#fad94c':'#e872b7'));
 	raidInfos.append($('<td>',{id: 'raidLevel_'+raid.gym_id, text: '★'.repeat(raid.level)}));


### PR DESCRIPTION
## Description
Fixes the counter on raids page showing NaN since Date parsing seems not equally implemented in all browsers.
-> Slightly modify Date string to be correctly parsed in Safari.

## Motivation and Context
Currently counter on raid page shows NaN.

## How Has This Been Tested?
Tested on Safari on OSX on own instance.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
