### PR TITLE
Add info for failed and empty raids request

### DIFF
--- a/core/css/style.css
+++ b/core/css/style.css
@@ -522,12 +522,12 @@ raids styles
 	line-height: 2em;
 }
 
-#raidsContainer td:first-child {
+#raidsContainer td.level {
     color: #fff;
     text-shadow: 0 0 6px black;
 }
 
-#raidsContainer td:last-child {
+#raidsContainer td:nth-child(6) {
 	min-width: 175px;
 }
 
@@ -540,7 +540,7 @@ raids styles
 		left: 17px;
 		top: 8px;
 	}
-	#raidsContainer td:last-child {
+	#raidsContainer td:nth-child(6) {
 		display: none;
 	}
 	#raidsTable>tbody>tr>td, #raidsTable>tbody>tr>th, #raidsTable>tfoot>tr>td, #raidsTable>tfoot>tr>th, #raidsTable>thead>tr>td, #raidsTable>thead>tr>th {

--- a/core/js/raids.content.js
+++ b/core/js/raids.content.js
@@ -25,17 +25,26 @@ function loadRaids(page, pokeimg_suffix, location_url) {
 		}
 	}).done(function (data) {
 		var internalIndex = 0;
+		if (data.raids.length == 0) {
+			var raidInfos = $('<tr>');
+			raidInfos.append($('<td>',{colspan: 6, text: data.locale.noraids})).css('text-align', 'center');
+			$('#raidsContainer').append(raidInfos);
+		}
 		$.each(data.raids, function (gym_id, raid) {
 			internalIndex++;
 			printRaid(raid, pokeimg_suffix, location_url);
 		});
-		if(internalIndex < 10){
+		if (internalIndex < 10) {
 			$('#loadMoreButton').hide();
-		}
-		else{
+		} else {
 			$('#loadMoreButton').removeClass('hidden');
 			$('#loadMoreButton').show();
 		}
+	}).fail(function() {
+		var raidInfos = $('<tr>');
+		raidInfos.append($('<td>',{colspan: 6, text: 'ERROR'})).css('text-align', 'center');
+		$('#raidsContainer').append(raidInfos);
+	}).always(function() {
 		$('.raidsLoader').hide();
 	});
 };
@@ -46,7 +55,7 @@ function printRaid(raid, pokeimg_suffix, location_url) {
 	var raidEnd = new Date(raid.end.replace(/-/g, '/'));
 
 	var raidInfos = $('<tr>',{id: 'raidInfos_'+raid.gym_id}).css('border-bottom','2px solid '+(raid.level>2?'#fad94c':'#e872b7'));
-	raidInfos.append($('<td>',{id: 'raidLevel_'+raid.gym_id, text: '★'.repeat(raid.level)}));
+	raidInfos.append($('<td>',{id: 'raidLevel_'+raid.gym_id, class: 'level', text: '★'.repeat(raid.level)}));
 	raidInfos.append($('<td>',{id: 'raidTime_'+raid.gym_id, text: raid.starttime + ' - ' + raid.endtime}));
 	raidInfos.append($('<td>',{id: 'raidRemaining_'+raid.gym_id, class: 'pokemon-remaining'}).append($('<span>',{class: (raidStart < now ? 'current' : 'upcoming')})));
 

--- a/core/json/locales/DE/translations.json
+++ b/core/json/locales/DE/translations.json
@@ -116,6 +116,7 @@
 "RAIDS_LOAD_MORE": "Mehr",
 "RAIDS_METADESC": "Finde aktuelle und bald startende Raids",
 "RAIDS_METATITLE": "Raids",
+"RAIDS_NONE": "Derzeit finden leider keine Raids statt",
 "RAIDS_TABLE_BOSS": "Gegner",
 "RAIDS_TABLE_GYM": "Arena",
 "RAIDS_TABLE_LEVEL": "Level",

--- a/core/json/locales/EN/translations.json
+++ b/core/json/locales/EN/translations.json
@@ -116,6 +116,7 @@
 "RAIDS_LOAD_MORE": "Load more",
 "RAIDS_METADESC": "Find current and upcoming Raids",
 "RAIDS_METATITLE": "Raids",
+"RAIDS_NONE": "Unfortunately, there are no raids currently",
 "RAIDS_TABLE_BOSS": "Boss",
 "RAIDS_TABLE_GYM": "Gym",
 "RAIDS_TABLE_LEVEL": "Level",

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -684,6 +684,7 @@ switch ($request) {
 		$json = array();
 		$json['raids'] = $raids;
 		$locale = array();
+		$locale['noraids'] = $locales->RAIDS_NONE;
 		$json['locale'] = $locale;
 
 		header('Content-Type: application/json');


### PR DESCRIPTION
## Description
Add message if no raids are found or if the request failed.
Translation added for english and german language, others have to be updated separately.

## Motivation and Context
Currently, the user will not be informed in such cases.

## How Has This Been Tested?
Tested on own instance.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
