### PR TITLE
Display deployment duration for Pokémon on trainers page

### DIFF
--- a/core/js/trainer.content.js
+++ b/core/js/trainer.content.js
@@ -160,7 +160,7 @@ function printTrainer(trainer, trainerIndex,pokeimg_suffix,iv_numbers, locale) {
 function printPokemon(pokemon,pokeimg_suffix,iv_numbers,locale){
 	var trainerPokemon = $('<div>',{id : 'trainerPokemon_'+pokemon.pokemon_uid, class: "col-md-1 col-xs-4 pokemon-single", style: "text-align: center" });
 	var gymClass = "";
-	if ((pokemon.gym_id===null)) {
+	if (pokemon.gym_id === null) {
 		gymClass = "unseen";
 	}
 	trainerPokemon.append(
@@ -245,12 +245,15 @@ function printPokemon(pokemon,pokeimg_suffix,iv_numbers,locale){
 	trainerPokemon.append(progressBar);
 	if (pokemon.last_scanned === '0') {
 		trainerPokemon.append($('<small>',{text: locale.today}));
-	}
-	else if (pokemon.last_scanned === '1') {
+	} else if (pokemon.last_scanned === '1') {
 		trainerPokemon.append($('<small>',{text: pokemon.last_scanned + " " + locale.day}));
-	}
-	else {
+	} else {
 		trainerPokemon.append($('<small>',{text: pokemon.last_scanned + " " + locale.days}));
+	}
+	if (pokemon.deployment_time) {
+		var diff = (new Date() - new Date(pokemon.deployment_time.replace(/-/g, '/'))) / 1000;
+		trainerPokemon.append($('<br>'));
+		trainerPokemon.append($('<small>',{text: parseInt(diff / 3600) + 'h ' + parseInt((diff / 60) % 60) + 'm'}));
 	}
 	return trainerPokemon;
 }

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -596,9 +596,9 @@ switch ($request) {
 			while ($data = $resultRanking->fetch_object()) {
 				$trainer->rank = $data->rank ;
 			}
-			$req = "(SELECT DISTINCT gympokemon.pokemon_id, gympokemon.pokemon_uid, gympokemon.cp, DATEDIFF(UTC_TIMESTAMP(), gympokemon.last_seen) AS last_scanned, gympokemon.trainer_name, gympokemon.iv_defense, gympokemon.iv_stamina, gympokemon.iv_attack, filtered_gymmember.gym_id, '1' AS active
+			$req = "(SELECT DISTINCT gympokemon.pokemon_id, gympokemon.pokemon_uid, gympokemon.cp, DATEDIFF(UTC_TIMESTAMP(), gympokemon.last_seen) AS last_scanned, gympokemon.trainer_name, gympokemon.iv_defense, gympokemon.iv_stamina, gympokemon.iv_attack, filtered_gymmember.gym_id, filtered_gymmember.deployment_time as deployment_time, '1' AS active
 					FROM gympokemon INNER JOIN
-					(SELECT gymmember.pokemon_uid, gymmember.gym_id FROM gymmember GROUP BY gymmember.pokemon_uid, gymmember.gym_id HAVING gymmember.gym_id <> '') AS filtered_gymmember
+					(SELECT * FROM gymmember GROUP BY gymmember.pokemon_uid, gymmember.gym_id HAVING gymmember.gym_id <> '') AS filtered_gymmember
 					ON gympokemon.pokemon_uid = filtered_gymmember.pokemon_uid
 					WHERE gympokemon.trainer_name='".$trainer->name."'
 					ORDER BY gympokemon.cp DESC)";
@@ -613,15 +613,14 @@ switch ($request) {
 			}
 			$trainer->gyms = $active_gyms;
 
-			$req = "(SELECT DISTINCT gympokemon.pokemon_id, gympokemon.pokemon_uid, gympokemon.cp, DATEDIFF(UTC_TIMESTAMP(), gympokemon.last_seen) AS last_scanned, gympokemon.trainer_name, gympokemon.iv_defense, gympokemon.iv_stamina, gympokemon.iv_attack, null AS gym_id, '0' AS active
+			$req = "(SELECT DISTINCT gympokemon.pokemon_id, gympokemon.pokemon_uid, gympokemon.cp, DATEDIFF(UTC_TIMESTAMP(), gympokemon.last_seen) AS last_scanned, gympokemon.trainer_name, gympokemon.iv_defense, gympokemon.iv_stamina, gympokemon.iv_attack, null AS gym_id, filtered_gymmember.deployment_time as deployment_time, '0' AS active
 					FROM gympokemon LEFT JOIN
 					(SELECT * FROM gymmember HAVING gymmember.gym_id <> '') AS filtered_gymmember
 					ON gympokemon.pokemon_uid = filtered_gymmember.pokemon_uid
 					WHERE filtered_gymmember.pokemon_uid IS NULL AND gympokemon.trainer_name='".$trainer->name."'
-					ORDER BY gympokemon.cp DESC )";
+					ORDER BY gympokemon.cp DESC)";
 
 			$resultPkms = $mysqli->query($req);
-
 			while ($resultPkms && $dataPkm = $resultPkms->fetch_object()) {
 				$trainer->pokemons[$pkmCount++] = $dataPkm;
 			}

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -598,7 +598,7 @@ switch ($request) {
 			}
 			$req = "(SELECT DISTINCT gympokemon.pokemon_id, gympokemon.pokemon_uid, gympokemon.cp, DATEDIFF(UTC_TIMESTAMP(), gympokemon.last_seen) AS last_scanned, gympokemon.trainer_name, gympokemon.iv_defense, gympokemon.iv_stamina, gympokemon.iv_attack, filtered_gymmember.gym_id, filtered_gymmember.deployment_time as deployment_time, '1' AS active
 					FROM gympokemon INNER JOIN
-					(SELECT * FROM gymmember GROUP BY gymmember.pokemon_uid, gymmember.gym_id HAVING gymmember.gym_id <> '') AS filtered_gymmember
+					(SELECT gymmember.pokemon_uid, gymmember.gym_id, gymdetails.name, gymmember.deployment_time FROM gymmember GROUP BY gymmember.pokemon_uid, gymmember.gym_id HAVING gymmember.gym_id <> '') AS filtered_gymmember
 					ON gympokemon.pokemon_uid = filtered_gymmember.pokemon_uid
 					WHERE gympokemon.trainer_name='".$trainer->name."'
 					ORDER BY gympokemon.cp DESC)";


### PR DESCRIPTION
## Description
Add the deployment time in the format "XXh XXm" for every currently deployed Pokémon of a trainer.

## Screenshots (if appropriate):
![bildschirmfoto 2017-08-15 um 13 24 08](https://user-images.githubusercontent.com/727517/29314153-10691df0-81bd-11e7-90e7-17710363876e.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
