### PR TITLE
Use location_url for recent spawns

### DIFF
--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -177,7 +177,7 @@ switch ($request) {
 			if ($last_uid_param != $pokeuid) {
 				$last_seen = strtotime($data->disappear_time_real);
 
-				$location_link = $config->system->location_url || 'https://maps.google.com/?q={latitude},{longitude}&ll={latitude},{longitude}&z=16';
+				$location_link = isset($config->system->location_url) ? $config->system->location_url : 'https://maps.google.com/?q={latitude},{longitude}&ll={latitude},{longitude}&z=16';
 				$location_link = str_replace('{latitude}', $data->latitude, $location_link);
 				$location_link = str_replace('{longitude}', $data->longitude, $location_link);
 

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -177,9 +177,9 @@ switch ($request) {
 			if ($last_uid_param != $pokeuid) {
 				$last_seen = strtotime($data->disappear_time_real);
 
-				$last_location = new stdClass();
-				$last_location->latitude = $data->latitude;
-				$last_location->longitude = $data->longitude;
+				$location_link = $config->system->location_url || 'https://maps.google.com/?q={latitude},{longitude}&ll={latitude},{longitude}&z=16';
+				$location_link = str_replace('{latitude}', $data->latitude, $location_link);
+				$location_link = str_replace('{longitude}', $data->longitude, $location_link);
 
 				if ($config->system->recents_show_iv) {
 					$iv = new stdClass();
@@ -198,8 +198,8 @@ switch ($request) {
 			    <div class="col-md-1 col-xs-4 pokemon-single" data-pokeid="'.$pokeid.'" data-pokeuid="'.$pokeuid.'" style="display: none;">
 				<a href="pokemon/'.$pokeid.'"><img src="core/pokemons/'.$pokeid.$config->system->pokeimg_suffix.'" alt="'.$pokemons->pokemon->$pokeid->name.'" class="img-responsive"></a>
 				<a href="pokemon/'.$pokeid.'"><p class="pkmn-name">'.$pokemons->pokemon->$pokeid->name.'</p></a>
-				<a href="https://maps.google.com/?q='.$last_location->latitude.','.$last_location->longitude.'&ll='.$last_location->latitude.','.$last_location->longitude.'&z=16" target="_blank">
-				    <small class="pokemon-timer">00:00:00</small>
+				<a href="'.$location_link.'" target="_blank">
+					<small class="pokemon-timer">00:00:00</small>
 				</a>';
 				if ($config->system->recents_show_iv) {
 					if ($iv->available) {

--- a/core/process/data.loader.php
+++ b/core/process/data.loader.php
@@ -448,7 +448,7 @@ else {
 			$recent->uid = $data->encounter_id;
 			$recent->last_seen = strtotime($data->disappear_time_real);
 
-			$location_link = $config->system->location_url || 'https://maps.google.com/?q={latitude},{longitude}&ll={latitude},{longitude}&z=16';
+			$location_link = isset($config->system->location_url) ? $config->system->location_url : 'https://maps.google.com/?q={latitude},{longitude}&ll={latitude},{longitude}&z=16';
 			$location_link = str_replace('{latitude}', $data->latitude, $location_link);
 			$location_link = str_replace('{longitude}', $data->longitude, $location_link);
 			$recent->location_link = $location_link;

--- a/core/process/data.loader.php
+++ b/core/process/data.loader.php
@@ -448,9 +448,10 @@ else {
 			$recent->uid = $data->encounter_id;
 			$recent->last_seen = strtotime($data->disappear_time_real);
 
-			$recent->last_location = new stdClass();
-			$recent->last_location->latitude = $data->latitude;
-			$recent->last_location->longitude = $data->longitude;
+			$location_link = $config->system->location_url || 'https://maps.google.com/?q={latitude},{longitude}&ll={latitude},{longitude}&z=16';
+			$location_link = str_replace('{latitude}', $data->latitude, $location_link);
+			$location_link = str_replace('{longitude}', $data->longitude, $location_link);
+			$recent->location_link = $location_link;
 
 			if ($config->system->recents_show_iv) {
 				$recent->iv = new stdClass();

--- a/pages/home.page.php
+++ b/pages/home.page.php
@@ -68,7 +68,7 @@
 			<div class="col-md-1 col-xs-4 pokemon-single" data-pokeid="<?= $id ?>" data-pokeuid="<?= $uid ?>" >
 				<a href="pokemon/<?= $id ?>"><img src="core/pokemons/<?= $id.$config->system->pokeimg_suffix ?>" alt="<?= $pokemons->pokemon->$id->name ?>" class="img-responsive"></a>
 				<a href="pokemon/<?= $id ?>"><p class="pkmn-name"><?= $pokemons->pokemon->$id->name ?></p></a>
-				<a href="https://maps.google.com/?q=<?= $pokemon->last_location->latitude ?>,<?= $pokemon->last_location->longitude ?>&ll=<?= $pokemon->last_location->latitude ?>,<?= $pokemon->last_location->longitude ?>&z=16" target="_blank">
+				<a href="<?= $pokemon->location_link ?>" target="_blank">
 					<small class="pokemon-timer">00:00:00</small>
 				</a>
 				<?php


### PR DESCRIPTION
## Description
Use the recently introduced configuration variable `system->location_url`(currently only used on raids page) also for the links to the location (placed on the remaining time) of recent mythic Pokémon on the home page.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
