### PR TITLE
Add trainer blacklist

### DIFF
--- a/core/js/trainer.graph.js.php
+++ b/core/js/trainer.graph.js.php
@@ -29,7 +29,11 @@ if ($mysqli->connect_error != '') {
 $trainer_lvl = [];
 # For all 3 teams
 for ($teamid = 1; $teamid <= 3; $teamid++) {
-	$req = "SELECT level, count(level) AS count FROM trainer WHERE team = '".$teamid."' GROUP BY level";
+	$req = "SELECT level, count(level) AS count FROM trainer WHERE team = '".$teamid."'";
+	if (!empty($config->system->trainer_blacklist)) {
+		$req .= " AND name NOT IN ('".implode("','", $config->system->trainer_blacklist)."')";
+	}
+	$req .= " GROUP BY level";
 	if ($result = $mysqli->query($req)) {
 		# build level=>count array
 		$data = [];

--- a/core/json/variables.examples.json
+++ b/core/json/variables.examples.json
@@ -35,7 +35,8 @@
 		"iv_numbers"			:	false,
 		"forced_lang"			:	"",
 		"default_lang"			:	"en",
-		"location_url"			:	"/map/?lat={latitude}&lon={longitude}"
+		"location_url"			:	"/map/?lat={latitude}&lon={longitude}",
+		"trainer_blacklist"		:	["cheater1", "cheater2"]
 	},
 	"menu":[
 		{

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -553,7 +553,10 @@ switch ($request) {
 		}
 		if (isset($_GET['team']) && $_GET['team'] != 0) {
 			$team = mysqli_real_escape_string($mysqli, $_GET['team']);
-			$where .= ($where == "" ? " HAVING" : "AND ")." team = ".$team;
+			$where .= ($where == "" ? " HAVING" : " AND")." team = ".$team;
+		}
+		if (!empty($config->system->trainer_blacklist)) {
+			$where .= ($where == "" ? " HAVING" : " AND")." name NOT IN ('".implode("','", $config->system->trainer_blacklist)."')";
 		}
 		if (isset($_GET['page'])) {
 			$page = mysqli_real_escape_string($mysqli, $_GET['page']);

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -596,7 +596,10 @@ switch ($request) {
 			$trainers[$data->name] = $data;
 		}
 		foreach ($trainers as $trainer) {
-			$reqRanking = "SELECT COUNT(1) AS rank FROM trainer WHERE trainer.level >= ".$trainer->level;
+			$reqRanking = "SELECT COUNT(1) AS rank FROM trainer WHERE level = ".$trainer->level;
+			if (!empty($config->system->trainer_blacklist)) {
+				$reqRanking .= " AND name NOT IN ('".implode("','", $config->system->trainer_blacklist)."')";
+			}
 			$resultRanking = $mysqli->query($reqRanking);
 			while ($data = $resultRanking->fetch_object()) {
 				$trainer->rank = $data->rank;

--- a/core/process/data.loader.php
+++ b/core/process/data.loader.php
@@ -214,10 +214,15 @@ if (!empty($page)) {
 			$best_direction = isset($_GET['direction']) ? 'ASC' : 'DESC';
 			$best_direction = !isset($_GET['order']) && !isset($_GET['direction']) ? 'DESC' : $best_direction;
 			
+			$trainer_blacklist = "";
+			if (!empty($config->system->trainer_blacklist)) {
+				$trainer_blacklist = " AND trainer_name NOT IN ('".implode("','", $config->system->trainer_blacklist)."')";
+			}
+
 			$req = "SELECT trainer_name, ROUND(SUM(100*(iv_attack+iv_defense+iv_stamina)/45),1) AS IV, move_1, move_2, cp,
 					DATE_FORMAT(last_seen, '%Y-%m-%d') AS lasttime, last_seen
 					FROM gympokemon
-					WHERE pokemon_id = '".$pokemon_id."'
+					WHERE pokemon_id = '".$pokemon_id."'".$trainer_blacklist."
 					GROUP BY pokemon_uid
 					ORDER BY $best_order_by $best_direction, trainer_name ASC
 					LIMIT 0,50";


### PR DESCRIPTION
## Description
Add a variable to blacklist trainers to be not anymore shown or counted on trainers page as well as on the best Pokémon lists.

## Motivation and Context
We all have some known cheaters in our cities.
This provides a simple way of filtering them out of the stats.

## How Has This Been Tested?
Tested on own instance.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
