### PR TITLE
Fixed wrong time on Dashboard

### DIFF
--- a/core/js/dashboard.graph.js.php
+++ b/core/js/dashboard.graph.js.php
@@ -20,12 +20,17 @@ $config = json_decode(file_get_contents($variables));
 include_once(SYS_PATH.'/core/process/locales.loader.php');
 
 
-
 // Check if there's a pokemon stat file
 // ####################################
 
 $stats_file = SYS_PATH.'/core/json/pokemon.stats.json';
 $stats = json_decode(file_get_contents($stats_file));
+
+
+// Manage Time Interval
+// #####################
+
+include_once('../process/timezone.loader.php');
 
 
 $now = time();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Use timezone settings defined inside variables.json to fix dashboard always displaying UTC time.

## Description
<!--- Describe your changes in detail -->
Use timezone settings on the dashboard 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The dashboard always showed UTC time.
Should use timezone setting instead.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Testet it on local instance and it now shows time in correct timezone.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)