### PR TITLE
Generate image path for Pokemons in locales loader and use it everywhere

### DIFF
--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -196,7 +196,7 @@ switch ($request) {
 
 				$html = '
 			    <div class="col-md-1 col-xs-4 pokemon-single" data-pokeid="'.$pokeid.'" data-pokeuid="'.$pokeuid.'" style="display: none;">
-				<a href="pokemon/'.$pokeid.'"><img src="core/pokemons/'.$pokeid.$config->system->pokeimg_suffix.'" alt="'.$pokemons->pokemon->$pokeid->name.'" class="img-responsive"></a>
+				<a href="pokemon/'.$pokeid.'"><img src="'.$pokemons->pokemon->$pokeid->img.'" alt="'.$pokemons->pokemon->$pokeid->name.'" class="img-responsive"></a>
 				<a href="pokemon/'.$pokeid.'"><p class="pkmn-name">'.$pokemons->pokemon->$pokeid->name.'</p></a>
 				<a href="'.$location_link.'" target="_blank">
 					<small class="pokemon-timer">00:00:00</small>
@@ -456,11 +456,12 @@ switch ($request) {
 		while ($data = $result->fetch_object()) {
 			$gymData['gymDetails']['pokemons'][] = $data;
 			if ($data != false) {
+				$pokemon_id = $data->pokemon_id;
 				if ($config->system->iv_numbers) {
 					$gymData['infoWindow'] .= '
 					<div style="text-align: center; width: 50px; display: inline-block; margin-right: 3px">
 						<a href="pokemon/'.$data->pokemon_id.'">
-						<img src="core/pokemons/'.$data->pokemon_id.$config->system->pokeimg_suffix.'" height="50" style="display:inline-block" >
+						<img src="'.$pokemons->pokemon->$pokemon_id->img.'" height="50" style="display:inline-block" >
 						</a>
 						<p class="pkmn-name">'.$data->cp.'</p>
 						<div class="progress" style="height: 12px; margin-bottom: 0">
@@ -479,7 +480,7 @@ switch ($request) {
 					$gymData['infoWindow'] .= '
 					<div style="text-align: center; width: 50px; display: inline-block; margin-right: 3px">
 						<a href="pokemon/'.$data->pokemon_id.'">
-						<img src="core/pokemons/'.$data->pokemon_id.$config->system->pokeimg_suffix.'" height="50" style="display:inline-block" >
+						<img src="'.$pokemons->pokemon->$pokemon_id->img.'" height="50" style="display:inline-block" >
 						</a>
 						<p class="pkmn-name">'.$data->cp.'</p>
 						<div class="progress" style="height: 4px; width: 40px; margin-bottom: 10px; margin-top: 2px; margin-left: auto; margin-right: auto">
@@ -496,10 +497,11 @@ switch ($request) {
 					</div>'
 						; }
 			} else {
+				$pokemon_id = $gymData['gymDetails']['gymInfos']['guardPokemonId'];
 				$gymData['infoWindow'] .= '
 				<div style="text-align: center; width: 50px; display: inline-block; margin-right: 3px">
 					<a href="pokemon/'.$gymData['gymDetails']['gymInfos']['guardPokemonId'].'">
-					<img src="core/pokemons/'.$gymData['gymDetails']['gymInfos']['guardPokemonId'].$config->system->pokeimg_suffix.'" height="50" style="display:inline-block" >
+					<img src="'.$pokemons->pokemon->$pokemon_id->img.'" height="50" style="display:inline-block" >
 					</a>
 					<p class="pkmn-name">???</p>
 				</div>'
@@ -524,10 +526,11 @@ switch ($request) {
 			$gymData['gymDetails']['gymInfos']['team'] = $data->team_id;
 			$gymData['gymDetails']['gymInfos']['guardPokemonId'] = $data->guard_pokemon_id;
 
+			$pokemon_id = $data->guard_pokemon_id;
 			$gymData['infoWindow'] .= '
 				<div style="text-align: center; width: 50px; display: inline-block; margin-right: 3px">
 					<a href="pokemon/'.$data->guard_pokemon_id.'">
-					<img src="core/pokemons/'.$data->guard_pokemon_id.$config->system->pokeimg_suffix.'" height="50" style="display:inline-block" >
+					<img src="'.$pokemons->pokemon->$pokemon_id->img.'" height="50" style="display:inline-block" >
 					</a>
 					<p class="pkmn-name">???</p>
 				</div>';

--- a/core/process/data.loader.php
+++ b/core/process/data.loader.php
@@ -106,16 +106,14 @@ if (!empty($page)) {
 			}
 
 
-			$pokemon			= new stdClass();
-			$pokemon			= $pokemons->pokemon->$pokemon_id;
-			$pokemon->id = $pokemon_id;
-
+			$pokemon = new stdClass();
+			$pokemon = $pokemons->pokemon->$pokemon_id;
 
 			// Some math
 			// ----------
 
-			$pokemon->max_cp_percent 	= percent(3670, $pokemon->max_cp);
-			$pokemon->max_hp_percent 	= percent(411, $pokemon->max_hp);
+			$pokemon->max_cp_percent = percent(3670, $pokemon->max_cp);
+			$pokemon->max_hp_percent = percent(411, $pokemon->max_hp);
 
 
 			// Get Dabase results
@@ -247,9 +245,9 @@ if (!empty($page)) {
 
 			for ($i = 1; $i <= $max; $i++) {
 				$pokedex->$i = new stdClass();
-				$pokedex->$i->id 			= $i;
+				$pokedex->$i->id = $i;
 				$pokedex->$i->permalink = 'pokemon/'.$i;
-				$pokedex->$i->img			= 'core/pokemons/'.$i.$config->system->pokeimg_suffix;
+				$pokedex->$i->img = $pokemons->pokemon->$i->img;
 				$pokedex->$i->name = $pokemons->pokemon->$i->name;
 				$pokedex->$i->spawn = ($pokemons->pokemon->$i->spawn_count > 0) ? 1 : 0;
 				$pokedex->$i->spawn_count = $pokemons->pokemon->$i->spawn_count;

--- a/core/process/locales.loader.php
+++ b/core/process/locales.loader.php
@@ -173,8 +173,10 @@ $pokemon_counts = json_decode(file_get_contents($pokedex_counts_file));
 
 foreach ($pokemons->pokemon as $pokeid => $pokemon) {
 	// Merge name and description from translation files
+	$pokemon->id = $pokeid;
 	$pokemon->name = $pokemon_trans->pokemon->$pokeid->name;
 	$pokemon->description = $pokemon_trans->pokemon->$pokeid->description;
+	$pokemon->img = 'core/pokemons/'.$pokeid.$config->system->pokeimg_suffix;
 
 	// Replace quick and charge move with translation
 	$quick_move = $pokemon->quick_move;

--- a/pages/gym.page.php
+++ b/pages/gym.page.php
@@ -45,7 +45,7 @@
 
 				<div class="col-xs-4 pokemon-single">
 					<a href="pokemon/<?= $guardian ?>">
-					<img src="core/pokemons/<?= $guardian.$config->system->pokeimg_suffix ?>" alt="<?= $pokemons->pokemon->$guardian->name ?>" class="img-responsive" width=150>
+					<img src="<?= $pokemons->pokemon->$guardian->img ?>" alt="<?= $pokemons->pokemon->$guardian->name ?>" class="img-responsive" width=150>
 					</a>
 				</div>
 

--- a/pages/home.page.php
+++ b/pages/home.page.php
@@ -66,7 +66,7 @@
 			$id = $pokemon->id;
 			$uid = $pokemon->uid; ?>
 			<div class="col-md-1 col-xs-4 pokemon-single" data-pokeid="<?= $id ?>" data-pokeuid="<?= $uid ?>" >
-				<a href="pokemon/<?= $id ?>"><img src="core/pokemons/<?= $id.$config->system->pokeimg_suffix ?>" alt="<?= $pokemons->pokemon->$id->name ?>" class="img-responsive"></a>
+				<a href="pokemon/<?= $id ?>"><img src="<?= $pokemons->pokemon->$id->img ?>" alt="<?= $pokemons->pokemon->$id->name ?>" class="img-responsive"></a>
 				<a href="pokemon/<?= $id ?>"><p class="pkmn-name"><?= $pokemons->pokemon->$id->name ?></p></a>
 				<a href="<?= $pokemon->location_link ?>" target="_blank">
 					<small class="pokemon-timer">00:00:00</small>

--- a/pages/pokemon.page.php
+++ b/pages/pokemon.page.php
@@ -62,7 +62,7 @@
 
 	<div class="col-md-2 col-xs-4">
 		<div id="poke-img" style="padding-top:15px;margin-bottom:1em;">
-			<img class="media-object img-responsive" src="core/pokemons/<?= $pokemon->id.$config->system->pokeimg_suffix ?>" alt="<?= $pokemon->name ?> model" >
+			<img class="media-object img-responsive" src="<?= $pokemon->img ?>" alt="<?= $pokemon->name ?> model" >
 		</div>
 	</div>
 
@@ -272,7 +272,7 @@
 			<div class="col-md-1 col-sm-2 col-xs-3 pokemon-single">
 
 				<a href="pokemon/<?= $related_mon ?>">
-					<img src="core/pokemons/<?= $related_mon.$config->system->pokeimg_suffix ?>" alt="<?= $pokemons->pokemon->$related_mon->name.$config->system->pokeimg_suffix ?>" class="img-responsive">
+					<img src="<?= $pokemons->pokemon->$related_mon->img ?>" alt="<?= $pokemons->pokemon->$related_mon->name ?>" class="img-responsive">
 				</a>
 
 			</div>


### PR DESCRIPTION
## Description
Construct the image path for Pokemons only once in the locales loader and use it in all *.php files.
(The *.js files do still generate it on their own.)

## Motivation and Context
Currently, the image path for a Pokemon is constructed always when it is used, which leads to bad maintainability.

## How Has This Been Tested?
Tested on own instance (with having all images for Pokemon > 251 pointing to a dummy).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
