### PR TITLE
Respect max_pokemon variable in locales loader

### DIFF
--- a/core/process/locales.loader.php
+++ b/core/process/locales.loader.php
@@ -173,6 +173,9 @@ $pokemon_counts = json_decode(file_get_contents($pokedex_counts_file));
 
 $maxpid = $config->system->max_pokemon;
 for ($pokeid = 1; $pokeid <= $maxpid; $pokeid++) {
+	if (!isset($pokemons->pokemon->$pokeid)) {
+		continue;
+	}
 	// Merge name and description from translation files
 	$pokemon = $pokemons->pokemon->$pokeid;
 	$pokemon->id = $pokeid;

--- a/core/process/locales.loader.php
+++ b/core/process/locales.loader.php
@@ -171,8 +171,10 @@ $pokemons_rarity = json_decode(file_get_contents($pokedex_rarity_file));
 $pokedex_counts_file = SYS_PATH.'/core/json/pokedex.counts.json';
 $pokemon_counts = json_decode(file_get_contents($pokedex_counts_file));
 
-foreach ($pokemons->pokemon as $pokeid => $pokemon) {
+$maxpid = $config->system->max_pokemon;
+for ($pokeid = 1; $pokeid <= $maxpid; $pokeid++) {
 	// Merge name and description from translation files
+	$pokemon = $pokemons->pokemon->$pokeid;
 	$pokemon->id = $pokeid;
 	$pokemon->name = $pokemon_trans->pokemon->$pokeid->name;
 	$pokemon->description = $pokemon_trans->pokemon->$pokeid->description;


### PR DESCRIPTION
## Description
The locales loader was processing all pokemon that were available in the pokedex file.
Since we have a max_pokemon variable, this should be also used there.

## How Has This Been Tested?
At own instance.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
