### PR TITLE
Fix meta icon path and type

### DIFF
--- a/core/meta-icons/browserconfig.xml
+++ b/core/meta-icons/browserconfig.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<browserconfig><msapplication><tile><square70x70logo src="/ms-icon-70x70.png"/><square150x150logo src="/ms-icon-150x150.png"/><square310x310logo src="/ms-icon-310x310.png"/><TileColor>#ffffff</TileColor></tile></msapplication></browserconfig>
+<browserconfig><msapplication><tile><square70x70logo src="ms-icon-70x70.png"/><square150x150logo src="ms-icon-150x150.png"/><square310x310logo src="ms-icon-310x310.png"/><TileColor>#ffffff</TileColor></tile></msapplication></browserconfig>

--- a/core/meta-icons/manifest.json
+++ b/core/meta-icons/manifest.json
@@ -2,37 +2,37 @@
 	"name": "Worldopole",
 	"icons": [
 		{
-			"src": "\/android-icon-36x36.png",
+			"src": "android-icon-36x36.png",
 			"sizes": "36x36",
 			"type": "image\/png",
 			"density": "0.75"
 		},
 		{
-			"src": "\/android-icon-48x48.png",
+			"src": "android-icon-48x48.png",
 			"sizes": "48x48",
 			"type": "image\/png",
 			"density": "1.0"
 		},
 		{
-			"src": "\/android-icon-72x72.png",
+			"src": "android-icon-72x72.png",
 			"sizes": "72x72",
 			"type": "image\/png",
 			"density": "1.5"
 		},
 		{
-			"src": "\/android-icon-96x96.png",
+			"src": "android-icon-96x96.png",
 			"sizes": "96x96",
 			"type": "image\/png",
 			"density": "2.0"
 		},
 		{
-			"src": "\/android-icon-144x144.png",
+			"src": "android-icon-144x144.png",
 			"sizes": "144x144",
 			"type": "image\/png",
 			"density": "3.0"
 		},
 		{
-			"src": "\/android-icon-192x192.png",
+			"src": "android-icon-192x192.png",
 			"sizes": "192x192",
 			"type": "image\/png",
 			"density": "4.0"

--- a/core/meta-icons/manifest.json
+++ b/core/meta-icons/manifest.json
@@ -4,37 +4,37 @@
 		{
 			"src": "android-icon-36x36.png",
 			"sizes": "36x36",
-			"type": "image\/png",
+			"type": "image/png",
 			"density": "0.75"
 		},
 		{
 			"src": "android-icon-48x48.png",
 			"sizes": "48x48",
-			"type": "image\/png",
+			"type": "image/png",
 			"density": "1.0"
 		},
 		{
 			"src": "android-icon-72x72.png",
 			"sizes": "72x72",
-			"type": "image\/png",
+			"type": "image/png",
 			"density": "1.5"
 		},
 		{
 			"src": "android-icon-96x96.png",
 			"sizes": "96x96",
-			"type": "image\/png",
+			"type": "image/png",
 			"density": "2.0"
 		},
 		{
 			"src": "android-icon-144x144.png",
 			"sizes": "144x144",
-			"type": "image\/png",
+			"type": "image/png",
 			"density": "3.0"
 		},
 		{
 			"src": "android-icon-192x192.png",
 			"sizes": "192x192",
-			"type": "image\/png",
+			"type": "image/png",
 			"density": "4.0"
 		}
 	]


### PR DESCRIPTION
## Description
I found a lot of 404 on mobile browsers trying to access the meta icons.
This seems to be due to the wrong src specified in the manifest.
> If src is a relative URL, the base URL will be the URL of the manifest.

Furthermore, I was wondering, why some values were escaped.
Since this seems to be not necessary, I removed the backslashes.

## How Has This Been Tested?
Own instance.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
