### PR TITLE
Only include Pokemon until max_pokemon in $pokemons object

### DIFF
--- a/core/process/locales.loader.php
+++ b/core/process/locales.loader.php
@@ -163,7 +163,7 @@ unset($pokemon_trans_array);
 ##########################################################################
 
 $pokedex_file = file_get_contents(SYS_PATH.'/core/json/pokedex.json');
-$pokemons = json_decode($pokedex_file);
+$pokemons_all = json_decode($pokedex_file);
 
 $pokedex_rarity_file = SYS_PATH.'/core/json/pokedex.rarity.json';
 $pokemons_rarity = json_decode(file_get_contents($pokedex_rarity_file));
@@ -171,13 +171,16 @@ $pokemons_rarity = json_decode(file_get_contents($pokedex_rarity_file));
 $pokedex_counts_file = SYS_PATH.'/core/json/pokedex.counts.json';
 $pokemon_counts = json_decode(file_get_contents($pokedex_counts_file));
 
+$pokemons = new stdClass();
+$pokemons->pokemon = new stdClass();
+
 $maxpid = $config->system->max_pokemon;
 for ($pokeid = 1; $pokeid <= $maxpid; $pokeid++) {
-	if (!isset($pokemons->pokemon->$pokeid)) {
+	if (!isset($pokemons_all->pokemon->$pokeid)) {
 		continue;
 	}
 	// Merge name and description from translation files
-	$pokemon = $pokemons->pokemon->$pokeid;
+	$pokemon = $pokemons_all->pokemon->$pokeid;
 	$pokemon->id = $pokeid;
 	$pokemon->name = $pokemon_trans->pokemon->$pokeid->name;
 	$pokemon->description = $pokemon_trans->pokemon->$pokeid->description;
@@ -209,7 +212,7 @@ for ($pokeid = 1; $pokeid <= $maxpid; $pokeid++) {
 			$move->$move_id->name = $move_name->name;
 		}
 	}
-	
+
 	// Add pokemon counts to array
 	$pokemon->spawn_count = $pokemon_counts->$pokeid;
 
@@ -235,6 +238,8 @@ for ($pokeid = 1; $pokeid <= $maxpid; $pokeid++) {
 	} else {
 		$pokemon->rarity = $locales->UNSEEN;
 	}
+
+	$pokemons->pokemon->$pokeid = $pokemon;
 }
 
 // Add total pokemon count
@@ -242,7 +247,7 @@ $pokemons->total = $pokemon_counts->total;
 
 // Translate typecolors array keys as well
 $types_temp = new stdClass();
-foreach ($pokemons->typecolors as $type => $color) {
+foreach ($pokemons_all->typecolors as $type => $color) {
 	$type_trans = $pokemon_trans->types->$type;
 	$types_temp->$type_trans = $color;
 }
@@ -265,6 +270,7 @@ unset($pokemon_trans);
 unset($types_temp);
 unset($type_trans);
 unset($pokemons_rarity);
+unset($pokemons_all);
 unset($quick_move);
 unset($charge_move);
 unset($candy_id);


### PR DESCRIPTION
## Description
Only include Pokemon within the value of the max_pokemon system variable in the often used $pokemons object to prevent PHP Notice messages.

## Motivation and Context
With the latest changes that introduced the usage of max_pokemon in locales_loader there was a minor problem that caused PHP Notice messages for unset properties.
This was caused by iterating over all available Pokemon from the pokedex file but only injecting data for those within max_pokemon.

## How Has This Been Tested?
Local test instance.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)