### PR TITLE
Make directory check portable

### DIFF
--- a/config.example.php
+++ b/config.example.php
@@ -53,14 +53,6 @@ if (isset($_SERVER['HTTP_HOST'])) {
 ## Subdirectory trick
 function directory()
 {
-	$root = $_SERVER['DOCUMENT_ROOT'];
-	$filePath = dirname(__FILE__);
-
-	if ($root == $filePath) {
-		return ''; // installed in the root
-	} else {
-		$subdir_path = explode('/', $filePath);
-		$subdir = end($subdir_path);
-		return $subdir;
-	}
+	##https://stackoverflow.com/questions/2090723/how-to-get-the-relative-directory-no-matter-from-where-its-included-in-php
+	return substr(str_replace('\\', '/', realpath(dirname(__FILE__))), strlen(str_replace('\\', '/', realpath($_SERVER['DOCUMENT_ROOT']))));
 }

--- a/config.example.php
+++ b/config.example.php
@@ -54,5 +54,5 @@ if (isset($_SERVER['HTTP_HOST'])) {
 function directory()
 {
 	##https://stackoverflow.com/questions/2090723/how-to-get-the-relative-directory-no-matter-from-where-its-included-in-php
-	return substr(str_replace('\\', '/', realpath(dirname(__FILE__))), strlen(str_replace('\\', '/', realpath($_SERVER['DOCUMENT_ROOT']))));
+	return substr(str_replace('\\', '/', realpath(dirname(__FILE__))), strlen(str_replace('\\', '/', realpath($_SERVER['DOCUMENT_ROOT']))) + 1);
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The current function did not work properly on Windows as there is a mismatch on slashes between what was returned by dirname and document_root.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Helping to setup an installation in Windows I needed to debug why all links were using the local path which lead to finding this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in a no subdir windows install, SO says that's the really portable way to do with 20 upvotes but not really tested outside that installation.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
