### PR TITLE
setting the real path value for the server['doucment_root'] so it hon…

### DIFF
--- a/config.example.php
+++ b/config.example.php
@@ -53,6 +53,8 @@ if (isset($_SERVER['HTTP_HOST'])) {
 ## Subdirectory trick
 function directory()
 {
+	# Get the realpath to honor symlinks
+	$_SERVER['DOCUMENT_ROOT'] = realpath($_SERVER['DOCUMENT_ROOT']);
 	$root = $_SERVER['DOCUMENT_ROOT'];
 	$filePath = dirname(__FILE__);
 


### PR DESCRIPTION
Correctly honor symlinks for the Server['doucment_root'] 

## Description
There is an issue where config.php is trying to compare the root web server document root and the file path to see if its located under a sub directory.  When the path of `$_SERVER['DOCUMENT_ROOT']`
contains a symlink it does not honor that value.  Thus $root and $filePath are different and then it incorrectly sets the $subdirectory var making the site un-usable

## Motivation and Context
Allowing correct function of config.php to work with symlink directory structures

## How Has This Been Tested?
Tested this on Linux CentOS 7 with a symlinked directory structure where my /opt directory is symlinked under a logical volume /vol0.  Before the change I had updated the if statement that called the directory function to always set the `$subdirectory = '/';`.  After the change I am able to undo my changes to the if statement.  

You can see a working site here http://wbpogo.com/

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)