### PR TITLE
Fix timers on home page

### DIFF
--- a/pages/home.page.php
+++ b/pages/home.page.php
@@ -174,7 +174,7 @@
 <script>
 	document.addEventListener('DOMContentLoaded', function() {
 		<?php
-		foreach (array_reverse($timers) as $id => $countdown) { ?>
+		foreach (array_reverse($timers, true) as $id => $countdown) { ?>
 			startTimer(<?= $countdown ?>,"<?= $id ?>");
 		<?php
 		} ?>


### PR DESCRIPTION
## Description
Fixed the timers of the latest spawns on the home page.

## Motivation and Context
RM changed the way the encounter ids are stored.
This seemed to break e.g. the timers on the homepage since the array_reverse function of php was struggling with the ids. Fortunately, this could be easily fixed by setting "preserve_keys".
Maybe there are also other places where something might be broken too.

## How Has This Been Tested?
Tested on own instance.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)