### PR TITLE
drastically increase loading of trainer page

### DIFF
--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -620,7 +620,7 @@ switch ($request) {
 
 			$req = "SELECT DISTINCT gympokemon.pokemon_id, gympokemon.pokemon_uid, gympokemon.cp, DATEDIFF(UTC_TIMESTAMP(), gympokemon.last_seen) AS last_scanned, gympokemon.trainer_name, gympokemon.iv_defense, gympokemon.iv_stamina, gympokemon.iv_attack, null AS gym_id, CONVERT_TZ(gymmember.deployment_time, '+00:00', '".$time_offset."') as deployment_time, '0' AS active
 					FROM gympokemon 
-                    LEFT JOIN gymmember ON gympokemon.pokemon_uid = gymmember.pokemon_uid
+					LEFT JOIN gymmember ON gympokemon.pokemon_uid = gymmember.pokemon_uid
 					WHERE gymmember.pokemon_uid IS NULL AND gympokemon.trainer_name='".$trainer->name."'
 					ORDER BY gympokemon.cp DESC";
 


### PR DESCRIPTION
Make sure that you have index on the following fileds:
trainer.name
gympokemon.trainer_name
gympokemon.pokemon_uid
gymmember.pokemon_uid

<!--- Provide a general summary of your changes in the Title above -->
Optimized SQL query of loading trainer data

## Description
<!--- Describe your changes in detail -->
Modifications in the query

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On bigger databases, trainer page loaded very slowly

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on my configuration with 32000 rows in trainer table, and 630000 rows in gympokemon table. Query ran about 4-6 times faster

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
