### PR TITLE
Update Ratings

### DIFF
--- a/core/json/pokedex.json
+++ b/core/json/pokedex.json
@@ -8,7 +8,7 @@
             "max_cp": 981,
             "max_hp": 82,
             "quick_move": "Vine Whip",
-            "rating": 3.5,
+            "rating": 2.5,
             "sta": 90,
             "types": [
                 "Grass",
@@ -23,7 +23,7 @@
             "max_cp": 1552,
             "max_hp": 105,
             "quick_move": "Vine Whip",
-            "rating": 5.5,
+            "rating": 4.5,
             "sta": 120,
             "types": [
                 "Grass",
@@ -38,7 +38,7 @@
             "max_cp": 2568,
             "max_hp": 137,
             "quick_move": "Vine Whip",
-            "rating": 8.5,
+            "rating": 7.5,
             "sta": 160,
             "types": [
                 "Grass",
@@ -53,7 +53,7 @@
             "max_cp": 831,
             "max_hp": 72,
             "quick_move": "Scratch",
-            "rating": 3.5,
+            "rating": 2.5,
             "sta": 78,
             "types": [
                 "Fire"
@@ -67,7 +67,7 @@
             "max_cp": 1484,
             "max_hp": 102,
             "quick_move": "Scratch",
-            "rating": 5.5,
+            "rating": 4.5,
             "sta": 116,
             "types": [
                 "Fire"
@@ -81,7 +81,7 @@
             "max_cp": 2686,
             "max_hp": 134,
             "quick_move": "Fire Spin",
-            "rating": 8.5,
+            "rating": 8,
             "sta": 156,
             "types": [
                 "Fire",
@@ -96,7 +96,7 @@
             "max_cp": 808,
             "max_hp": 80,
             "quick_move": "Bubble",
-            "rating": 3.5,
+            "rating": 2.5,
             "sta": 88,
             "types": [
                 "Water"
@@ -110,7 +110,7 @@
             "max_cp": 1324,
             "max_hp": 104,
             "quick_move": "Water Gun",
-            "rating": 5.5,
+            "rating": 4.5,
             "sta": 118,
             "types": [
                 "Water"
@@ -124,7 +124,7 @@
             "max_cp": 2291,
             "max_hp": 135,
             "quick_move": "Water Gun",
-            "rating": 8.5,
+            "rating": 8,
             "sta": 158,
             "types": [
                 "Water"
@@ -138,7 +138,7 @@
             "max_cp": 393,
             "max_hp": 82,
             "quick_move": "Bug Bite",
-            "rating": 1.5,
+            "rating": 1,
             "sta": 90,
             "types": [
                 "Bug"
@@ -152,7 +152,7 @@
             "max_cp": 419,
             "max_hp": 90,
             "quick_move": "Bug Bite",
-            "rating": 2.0,
+            "rating": 1,
             "sta": 100,
             "types": [
                 "Bug"
@@ -166,7 +166,7 @@
             "max_cp": 1701,
             "max_hp": 105,
             "quick_move": "Bug Bite",
-            "rating": 5.5,
+            "rating": 4,
             "sta": 120,
             "types": [
                 "Bug",
@@ -181,7 +181,7 @@
             "max_cp": 397,
             "max_hp": 74,
             "quick_move": "Bug Bite",
-            "rating": 1.5,
+            "rating": 1,
             "sta": 80,
             "types": [
                 "Bug",
@@ -196,7 +196,7 @@
             "max_cp": 392,
             "max_hp": 82,
             "quick_move": "Bug Bite",
-            "rating": 2.0,
+            "rating": 1,
             "sta": 90,
             "types": [
                 "Bug",
@@ -211,7 +211,7 @@
             "max_cp": 1777,
             "max_hp": 113,
             "quick_move": "Bug Bite",
-            "rating": 5.5,
+            "rating": 4,
             "sta": 130,
             "types": [
                 "Bug",
@@ -226,7 +226,7 @@
             "max_cp": 580,
             "max_hp": 74,
             "quick_move": "Tackle",
-            "rating": 2.5,
+            "rating": 1.5,
             "sta": 80,
             "types": [
                 "Flying",
@@ -241,7 +241,7 @@
             "max_cp": 1085,
             "max_hp": 110,
             "quick_move": "Wing Attack",
-            "rating": 5.0,
+            "rating": 3,
             "sta": 126,
             "types": [
                 "Flying",
@@ -271,7 +271,7 @@
             "max_cp": 588,
             "max_hp": 58,
             "quick_move": "Tackle",
-            "rating": 2.5,
+            "rating": 1.5,
             "sta": 60,
             "types": [
                 "Normal"
@@ -285,7 +285,7 @@
             "max_cp": 1549,
             "max_hp": 98,
             "quick_move": "Quick Attack",
-            "rating": 6.0,
+            "rating": 4.5,
             "sta": 110,
             "types": [
                 "Normal"
@@ -299,7 +299,7 @@
             "max_cp": 673,
             "max_hp": 74,
             "quick_move": "Peck",
-            "rating": 2.5,
+            "rating": 1.5,
             "sta": 80,
             "types": [
                 "Flying",
@@ -329,7 +329,7 @@
             "max_cp": 778,
             "max_hp": 66,
             "quick_move": "Poison Sting",
-            "rating": 3.0,
+            "rating": 2,
             "sta": 70,
             "types": [
                 "Poison"
@@ -343,7 +343,7 @@
             "max_cp": 1737,
             "max_hp": 105,
             "quick_move": "Acid",
-            "rating": 6.0,
+            "rating": 5.5,
             "sta": 120,
             "types": [
                 "Poison"
@@ -357,7 +357,7 @@
             "max_cp": 787,
             "max_hp": 66,
             "quick_move": "Thunder Shock",
-            "rating": 3.5,
+            "rating": 2.5,
             "sta": 70,
             "types": [
                 "Electric"
@@ -371,7 +371,7 @@
             "max_cp": 2025,
             "max_hp": 105,
             "quick_move": "Spark",
-            "rating": 6.0,
+            "rating": 6.5,
             "sta": 120,
             "types": [
                 "Electric"
@@ -385,7 +385,7 @@
             "max_cp": 1194,
             "max_hp": 90,
             "quick_move": "Mud Shot",
-            "rating": 4.0,
+            "rating": 2.5,
             "sta": 100,
             "types": [
                 "Ground"
@@ -399,7 +399,7 @@
             "max_cp": 2328,
             "max_hp": 129,
             "quick_move": "Mud Shot",
-            "rating": 8.0,
+            "rating": 5.5,
             "sta": 150,
             "types": [
                 "Ground"
@@ -413,7 +413,7 @@
             "max_cp": 736,
             "max_hp": 98,
             "quick_move": "Poison Sting",
-            "rating": 3.0,
+            "rating": 2,
             "sta": 110,
             "types": [
                 "Poison"
@@ -427,7 +427,7 @@
             "max_cp": 1218,
             "max_hp": 121,
             "quick_move": "Poison Sting",
-            "rating": 5.5,
+            "rating": 3.5,
             "sta": 140,
             "types": [
                 "Poison"
@@ -441,7 +441,7 @@
             "max_cp": 2338,
             "max_hp": 153,
             "quick_move": "Poison Jab",
-            "rating": 8.0,
+            "rating": 7,
             "sta": 180,
             "types": [
                 "Ground",
@@ -456,7 +456,7 @@
             "max_cp": 739,
             "max_hp": 83,
             "quick_move": "Poison Sting",
-            "rating": 3.0,
+            "rating": 2,
             "sta": 92,
             "types": [
                 "Poison"
@@ -470,7 +470,7 @@
             "max_cp": 1252,
             "max_hp": 107,
             "quick_move": "Poison Jab",
-            "rating": 5.5,
+            "rating": 3.5,
             "sta": 122,
             "types": [
                 "Poison"
@@ -484,7 +484,7 @@
             "max_cp": 2386,
             "max_hp": 138,
             "quick_move": "Poison Jab",
-            "rating": 7.5,
+            "rating": 7,
             "sta": 162,
             "types": [
                 "Ground",
@@ -499,7 +499,7 @@
             "max_cp": 1085,
             "max_hp": 121,
             "quick_move": "Pound",
-            "rating": 5.0,
+            "rating": 2.5,
             "sta": 140,
             "types": [
                 "Fairy"
@@ -513,7 +513,7 @@
             "max_cp": 2353,
             "max_hp": 160,
             "quick_move": "Pound",
-            "rating": 8.5,
+            "rating": 6.5,
             "sta": 190,
             "types": [
                 "Fairy"
@@ -527,7 +527,7 @@
             "max_cp": 774,
             "max_hp": 71,
             "quick_move": "Ember",
-            "rating": 3.0,
+            "rating": 2.5,
             "sta": 76,
             "types": [
                 "Fire"
@@ -541,7 +541,7 @@
             "max_cp": 2157,
             "max_hp": 126,
             "quick_move": "Fire Spin",
-            "rating": 7.0,
+            "rating": 7,
             "sta": 146,
             "types": [
                 "Fire"
@@ -555,7 +555,7 @@
             "max_cp": 713,
             "max_hp": 192,
             "quick_move": "Pound",
-            "rating": 4.5,
+            "rating": 2,
             "sta": 230,
             "types": [
                 "Fairy",
@@ -570,7 +570,7 @@
             "max_cp": 1906,
             "max_hp": 231,
             "quick_move": "Pound",
-            "rating": 8.5,
+            "rating": 5,
             "sta": 280,
             "types": [
                 "Fairy",
@@ -585,7 +585,7 @@
             "max_cp": 569,
             "max_hp": 74,
             "quick_move": "Bite",
-            "rating": 2.5,
+            "rating": 1.5,
             "sta": 80,
             "types": [
                 "Flying",
@@ -600,7 +600,7 @@
             "max_cp": 1830,
             "max_hp": 129,
             "quick_move": "Wing Attack",
-            "rating": 6.5,
+            "rating": 5.5,
             "sta": 150,
             "types": [
                 "Flying",
@@ -615,7 +615,7 @@
             "max_cp": 1069,
             "max_hp": 82,
             "quick_move": "Razor Leaf",
-            "rating": 3.5,
+            "rating": 2.5,
             "sta": 90,
             "types": [
                 "Grass",
@@ -630,7 +630,7 @@
             "max_cp": 1512,
             "max_hp": 105,
             "quick_move": "Razor Leaf",
-            "rating": 6.0,
+            "rating": 4,
             "sta": 120,
             "types": [
                 "Grass",
@@ -645,7 +645,7 @@
             "max_cp": 2367,
             "max_hp": 129,
             "quick_move": "Razor Leaf",
-            "rating": 8.0,
+            "rating": 6.5,
             "sta": 150,
             "types": [
                 "Grass",
@@ -660,7 +660,7 @@
             "max_cp": 836,
             "max_hp": 66,
             "quick_move": "Bug Bite",
-            "rating": 3.5,
+            "rating": 2,
             "sta": 70,
             "types": [
                 "Bug",
@@ -675,7 +675,7 @@
             "max_cp": 1657,
             "max_hp": 105,
             "quick_move": "Fury Cutter",
-            "rating": 6.0,
+            "rating": 4.5,
             "sta": 120,
             "types": [
                 "Bug",
@@ -690,7 +690,7 @@
             "max_cp": 902,
             "max_hp": 105,
             "quick_move": "Bug Bite",
-            "rating": 3.5,
+            "rating": 2.5,
             "sta": 120,
             "types": [
                 "Bug",
@@ -705,7 +705,7 @@
             "max_cp": 1937,
             "max_hp": 121,
             "quick_move": "Bug Bite",
-            "rating": 6.5,
+            "rating": 5.5,
             "sta": 140,
             "types": [
                 "Bug",
@@ -720,7 +720,7 @@
             "max_cp": 465,
             "max_hp": 27,
             "quick_move": "Mud Slap",
-            "rating": 1.0,
+            "rating": 2,
             "sta": 20,
             "types": [
                 "Ground"
@@ -734,7 +734,7 @@
             "max_cp": 1333,
             "max_hp": 66,
             "quick_move": "Mud Slap",
-            "rating": 3.5,
+            "rating": 5,
             "sta": 70,
             "types": [
                 "Ground"
@@ -748,7 +748,7 @@
             "max_cp": 638,
             "max_hp": 74,
             "quick_move": "Scratch",
-            "rating": 3.0,
+            "rating": 2,
             "sta": 80,
             "types": [
                 "Normal"
@@ -762,7 +762,7 @@
             "max_cp": 1539,
             "max_hp": 113,
             "quick_move": "Scratch",
-            "rating": 6.0,
+            "rating": 5.5,
             "sta": 130,
             "types": [
                 "Normal"
@@ -776,7 +776,7 @@
             "max_cp": 966,
             "max_hp": 90,
             "quick_move": "Water Gun",
-            "rating": 4.5,
+            "rating": 2.5,
             "sta": 100,
             "types": [
                 "Water"
@@ -790,7 +790,7 @@
             "max_cp": 2270,
             "max_hp": 137,
             "quick_move": "Water Gun",
-            "rating": 8.0,
+            "rating": 7,
             "sta": 160,
             "types": [
                 "Water"
@@ -804,7 +804,7 @@
             "max_cp": 1002,
             "max_hp": 74,
             "quick_move": "Scratch",
-            "rating": 3.5,
+            "rating": 2.5,
             "sta": 80,
             "types": [
                 "Fighting"
@@ -818,7 +818,7 @@
             "max_cp": 2105,
             "max_hp": 113,
             "quick_move": "Counter",
-            "rating": 6.5,
+            "rating": 5.5,
             "sta": 130,
             "types": [
                 "Fighting"
@@ -832,7 +832,7 @@
             "max_cp": 1110,
             "max_hp": 98,
             "quick_move": "Bite",
-            "rating": 5.0,
+            "rating": 3.5,
             "sta": 110,
             "types": [
                 "Fire"
@@ -846,7 +846,7 @@
             "max_cp": 2839,
             "max_hp": 153,
             "quick_move": "Fire Fang",
-            "rating": 8.0,
+            "rating": 8.5,
             "sta": 180,
             "types": [
                 "Fire"
@@ -860,7 +860,7 @@
             "max_cp": 695,
             "max_hp": 74,
             "quick_move": "Bubble",
-            "rating": 3.5,
+            "rating": 2.5,
             "sta": 80,
             "types": [
                 "Water"
@@ -874,7 +874,7 @@
             "max_cp": 1313,
             "max_hp": 113,
             "quick_move": "Bubble",
-            "rating": 6.0,
+            "rating": 4,
             "sta": 130,
             "types": [
                 "Water"
@@ -888,7 +888,7 @@
             "max_cp": 2441,
             "max_hp": 153,
             "quick_move": "Bubble",
-            "rating": 8.5,
+            "rating": 7,
             "sta": 180,
             "types": [
                 "Fighting",
@@ -931,7 +931,7 @@
             "max_cp": 2887,
             "max_hp": 98,
             "quick_move": "Psycho Cut",
-            "rating": 8.5,
+            "rating": 7,
             "sta": 110,
             "types": [
                 "Psychic"
@@ -945,7 +945,7 @@
             "max_cp": 1199,
             "max_hp": 121,
             "quick_move": "Low Kick",
-            "rating": 3.0,
+            "rating": 2.5,
             "sta": 140,
             "types": [
                 "Fighting"
@@ -959,7 +959,7 @@
             "max_cp": 1910,
             "max_hp": 137,
             "quick_move": "Low Kick",
-            "rating": 6.0,
+            "rating": 4.5,
             "sta": 160,
             "types": [
                 "Fighting"
@@ -973,7 +973,7 @@
             "max_cp": 2889,
             "max_hp": 153,
             "quick_move": "Counter",
-            "rating": 9.0,
+            "rating": 7,
             "sta": 180,
             "types": [
                 "Fighting"
@@ -987,7 +987,7 @@
             "max_cp": 916,
             "max_hp": 90,
             "quick_move": "Vine Whip",
-            "rating": 4.0,
+            "rating": 2.5,
             "sta": 100,
             "types": [
                 "Grass",
@@ -1002,7 +1002,7 @@
             "max_cp": 1475,
             "max_hp": 113,
             "quick_move": "Razor Leaf",
-            "rating": 6.0,
+            "rating": 4,
             "sta": 130,
             "types": [
                 "Grass",
@@ -1017,7 +1017,7 @@
             "max_cp": 2268,
             "max_hp": 137,
             "quick_move": "Razor Leaf",
-            "rating": 8.0,
+            "rating": 6.5,
             "sta": 160,
             "types": [
                 "Grass",
@@ -1032,7 +1032,7 @@
             "max_cp": 956,
             "max_hp": 74,
             "quick_move": "Bubble",
-            "rating": 3.5,
+            "rating": 3,
             "sta": 80,
             "types": [
                 "Poison",
@@ -1047,7 +1047,7 @@
             "max_cp": 2374,
             "max_hp": 137,
             "quick_move": "Poison Jab",
-            "rating": 8.5,
+            "rating": 7.5,
             "sta": 160,
             "types": [
                 "Poison",
@@ -1062,7 +1062,7 @@
             "max_cp": 1193,
             "max_hp": 74,
             "quick_move": "Rock Throw",
-            "rating": 3.5,
+            "rating": 2.5,
             "sta": 80,
             "types": [
                 "Ground",
@@ -1077,7 +1077,7 @@
             "max_cp": 1815,
             "max_hp": 98,
             "quick_move": "Mud Slap",
-            "rating": 6.0,
+            "rating": 4,
             "sta": 110,
             "types": [
                 "Ground",
@@ -1092,7 +1092,7 @@
             "max_cp": 2916,
             "max_hp": 137,
             "quick_move": "Rock Throw",
-            "rating": 9.0,
+            "rating": 7,
             "sta": 160,
             "types": [
                 "Ground",
@@ -1121,7 +1121,7 @@
             "max_cp": 2252,
             "max_hp": 113,
             "quick_move": "Fire Spin",
-            "rating": 7.0,
+            "rating": 7,
             "sta": 130,
             "types": [
                 "Fire"
@@ -1135,7 +1135,7 @@
             "max_cp": 1204,
             "max_hp": 153,
             "quick_move": "Water Gun",
-            "rating": 5.0,
+            "rating": 2.5,
             "sta": 180,
             "types": [
                 "Psychic",
@@ -1150,7 +1150,7 @@
             "max_cp": 2482,
             "max_hp": 160,
             "quick_move": "Confusion",
-            "rating": 8.5,
+            "rating": 6.5,
             "sta": 190,
             "types": [
                 "Psychic",
@@ -1165,7 +1165,7 @@
             "max_cp": 1083,
             "max_hp": 51,
             "quick_move": "Spark",
-            "rating": 3.5,
+            "rating": 3,
             "sta": 50,
             "types": [
                 "Electric",
@@ -1180,7 +1180,7 @@
             "max_cp": 2237,
             "max_hp": 90,
             "quick_move": "Thunder Shock",
-            "rating": 8.0,
+            "rating": 6,
             "sta": 100,
             "types": [
                 "Electric",
@@ -1195,7 +1195,7 @@
             "max_cp": 1092,
             "max_hp": 93,
             "quick_move": "Cut",
-            "rating": 4.0,
+            "rating": 4,
             "sta": 104,
             "types": [
                 "Flying",
@@ -1225,7 +1225,7 @@
             "max_cp": 2138,
             "max_hp": 105,
             "quick_move": "Steel Wing",
-            "rating": 6.5,
+            "rating": 6,
             "sta": 120,
             "types": [
                 "Flying",
@@ -1240,7 +1240,7 @@
             "max_cp": 899,
             "max_hp": 113,
             "quick_move": "Lick",
-            "rating": 4.5,
+            "rating": 3,
             "sta": 130,
             "types": [
                 "Water"
@@ -1254,7 +1254,7 @@
             "max_cp": 1894,
             "max_hp": 153,
             "quick_move": "Frost Breath",
-            "rating": 8.0,
+            "rating": 6,
             "sta": 180,
             "types": [
                 "Ice",
@@ -1269,7 +1269,7 @@
             "max_cp": 1269,
             "max_hp": 137,
             "quick_move": "Poison Jab",
-            "rating": 4.5,
+            "rating": 3,
             "sta": 160,
             "types": [
                 "Poison"
@@ -1283,7 +1283,7 @@
             "max_cp": 2709,
             "max_hp": 176,
             "quick_move": "Poison Jab",
-            "rating": 8.5,
+            "rating": 7,
             "sta": 210,
             "types": [
                 "Poison"
@@ -1297,7 +1297,7 @@
             "max_cp": 958,
             "max_hp": 58,
             "quick_move": "Tackle",
-            "rating": 3.0,
+            "rating": 2.5,
             "sta": 60,
             "types": [
                 "Water"
@@ -1311,7 +1311,7 @@
             "max_cp": 2475,
             "max_hp": 90,
             "quick_move": "Frost Breath",
-            "rating": 8.5,
+            "rating": 7.5,
             "sta": 100,
             "types": [
                 "Ice",
@@ -1326,7 +1326,7 @@
             "max_cp": 1002,
             "max_hp": 58,
             "quick_move": "Lick",
-            "rating": 3.5,
+            "rating": 2.5,
             "sta": 60,
             "types": [
                 "Ghost",
@@ -1341,7 +1341,7 @@
             "max_cp": 1716,
             "max_hp": 82,
             "quick_move": "Shadow Claw",
-            "rating": 5.5,
+            "rating": 4.5,
             "sta": 90,
             "types": [
                 "Ghost",
@@ -1356,7 +1356,7 @@
             "max_cp": 2619,
             "max_hp": 105,
             "quick_move": "Shadow Claw",
-            "rating": 8.5,
+            "rating": 7,
             "sta": 120,
             "types": [
                 "Ghost",
@@ -1371,7 +1371,7 @@
             "max_cp": 1002,
             "max_hp": 66,
             "quick_move": "Tackle",
-            "rating": 4.0,
+            "rating": 4,
             "sta": 70,
             "types": [
                 "Ground",
@@ -1386,7 +1386,7 @@
             "max_cp": 992,
             "max_hp": 105,
             "quick_move": "Pound",
-            "rating": 4.5,
+            "rating": 3,
             "sta": 120,
             "types": [
                 "Psychic"
@@ -1400,7 +1400,7 @@
             "max_cp": 2048,
             "max_hp": 145,
             "quick_move": "Confusion",
-            "rating": 8.0,
+            "rating": 6.5,
             "sta": 170,
             "types": [
                 "Psychic"
@@ -1414,7 +1414,7 @@
             "max_cp": 1386,
             "max_hp": 58,
             "quick_move": "Bubble",
-            "rating": 3.5,
+            "rating": 3,
             "sta": 60,
             "types": [
                 "Water"
@@ -1428,7 +1428,7 @@
             "max_cp": 2694,
             "max_hp": 98,
             "quick_move": "Bubble",
-            "rating": 7.5,
+            "rating": 6,
             "sta": 110,
             "types": [
                 "Water"
@@ -1442,7 +1442,7 @@
             "max_cp": 857,
             "max_hp": 74,
             "quick_move": "Spark",
-            "rating": 3.5,
+            "rating": 3,
             "sta": 80,
             "types": [
                 "Electric"
@@ -1456,7 +1456,7 @@
             "max_cp": 1900,
             "max_hp": 105,
             "quick_move": "Spark",
-            "rating": 5.5,
+            "rating": 6.5,
             "sta": 120,
             "types": [
                 "Electric"
@@ -1470,7 +1470,7 @@
             "max_cp": 1102,
             "max_hp": 105,
             "quick_move": "Confusion",
-            "rating": 4.5,
+            "rating": 3,
             "sta": 120,
             "types": [
                 "Grass",
@@ -1485,7 +1485,7 @@
             "max_cp": 2916,
             "max_hp": 160,
             "quick_move": "Extrasensory",
-            "rating": 9.0,
+            "rating": 8,
             "sta": 190,
             "types": [
                 "Grass",
@@ -1500,7 +1500,7 @@
             "max_cp": 943,
             "max_hp": 90,
             "quick_move": "Mud Slap",
-            "rating": 4.0,
+            "rating": 2.5,
             "sta": 100,
             "types": [
                 "Ground"
@@ -1514,7 +1514,7 @@
             "max_cp": 1691,
             "max_hp": 105,
             "quick_move": "Mud Slap",
-            "rating": 6.0,
+            "rating": 5,
             "sta": 120,
             "types": [
                 "Ground"
@@ -1556,7 +1556,7 @@
             "max_cp": 1322,
             "max_hp": 153,
             "quick_move": "Lick",
-            "rating": 5.5,
+            "rating": 4,
             "sta": 180,
             "types": [
                 "Normal"
@@ -1570,7 +1570,7 @@
             "max_cp": 1091,
             "max_hp": 74,
             "quick_move": "Tackle",
-            "rating": 4.0,
+            "rating": 3,
             "sta": 80,
             "types": [
                 "Poison"
@@ -1584,7 +1584,7 @@
             "max_cp": 2183,
             "max_hp": 113,
             "quick_move": "Acid",
-            "rating": 7.0,
+            "rating": 6.5,
             "sta": 130,
             "types": [
                 "Poison"
@@ -1598,7 +1598,7 @@
             "max_cp": 1679,
             "max_hp": 137,
             "quick_move": "Mud Slap",
-            "rating": 5.0,
+            "rating": 3,
             "sta": 160,
             "types": [
                 "Ground",
@@ -1613,7 +1613,7 @@
             "max_cp": 3300,
             "max_hp": 176,
             "quick_move": "Mud Slap",
-            "rating": 9.5,
+            "rating": 6.5,
             "sta": 210,
             "types": [
                 "Ground",
@@ -1628,7 +1628,7 @@
             "max_cp": 1469,
             "max_hp": 404,
             "quick_move": "Pound",
-            "rating": 7.5,
+            "rating": 5.5,
             "sta": 500,
             "types": [
                 "Normal"
@@ -1642,7 +1642,7 @@
             "max_cp": 2208,
             "max_hp": 113,
             "quick_move": "Vine Whip",
-            "rating": 8.0,
+            "rating": 5,
             "sta": 130,
             "types": [
                 "Grass"
@@ -1656,7 +1656,7 @@
             "max_cp": 2463,
             "max_hp": 176,
             "quick_move": "Low Kick",
-            "rating": 8.5,
+            "rating": 6.5,
             "sta": 210,
             "types": [
                 "Normal"
@@ -1670,7 +1670,7 @@
             "max_cp": 921,
             "max_hp": 58,
             "quick_move": "Water Gun",
-            "rating": 3.5,
+            "rating": 2,
             "sta": 60,
             "types": [
                 "Water"
@@ -1684,7 +1684,7 @@
             "max_cp": 1979,
             "max_hp": 98,
             "quick_move": "Water Gun",
-            "rating": 7.0,
+            "rating": 5.5,
             "sta": 110,
             "types": [
                 "Water"
@@ -1698,7 +1698,7 @@
             "max_cp": 1006,
             "max_hp": 82,
             "quick_move": "Mud Shot",
-            "rating": 3.5,
+            "rating": 2.5,
             "sta": 90,
             "types": [
                 "Water"
@@ -1712,7 +1712,7 @@
             "max_cp": 2040,
             "max_hp": 137,
             "quick_move": "Poison Jab",
-            "rating": 6.5,
+            "rating": 5.5,
             "sta": 160,
             "types": [
                 "Water"
@@ -1726,7 +1726,7 @@
             "max_cp": 926,
             "max_hp": 58,
             "quick_move": "Water Gun",
-            "rating": 3.5,
+            "rating": 3,
             "sta": 60,
             "types": [
                 "Water"
@@ -1755,7 +1755,7 @@
             "max_cp": 1984,
             "max_hp": 74,
             "quick_move": "Confusion",
-            "rating": 5.0,
+            "rating": 6,
             "sta": 80,
             "types": [
                 "Fairy",
@@ -1770,7 +1770,7 @@
             "max_cp": 2464,
             "max_hp": 121,
             "quick_move": "Fury Cutter",
-            "rating": 7.5,
+            "rating": 7,
             "sta": 140,
             "types": [
                 "Bug",
@@ -1785,7 +1785,7 @@
             "max_cp": 2512,
             "max_hp": 113,
             "quick_move": "Frost Breath",
-            "rating": 7.5,
+            "rating": 5.5,
             "sta": 130,
             "types": [
                 "Ice",
@@ -1800,7 +1800,7 @@
             "max_cp": 2196,
             "max_hp": 113,
             "quick_move": "Thunder Shock",
-            "rating": 7.5,
+            "rating": 6.5,
             "sta": 130,
             "types": [
                 "Electric"
@@ -1814,7 +1814,7 @@
             "max_cp": 2254,
             "max_hp": 113,
             "quick_move": "Ember",
-            "rating": 7.5,
+            "rating": 7,
             "sta": 130,
             "types": [
                 "Fire"
@@ -1828,7 +1828,7 @@
             "max_cp": 2770,
             "max_hp": 113,
             "quick_move": "Bug Bite",
-            "rating": 8.0,
+            "rating": 7,
             "sta": 130,
             "types": [
                 "Bug"
@@ -1842,7 +1842,7 @@
             "max_cp": 2488,
             "max_hp": 129,
             "quick_move": "Tackle",
-            "rating": 7.5,
+            "rating": 6.5,
             "sta": 150,
             "types": [
                 "Normal"
@@ -1856,7 +1856,7 @@
             "max_cp": 220,
             "max_hp": 43,
             "quick_move": "Splash",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 40,
             "types": [
                 "Water"
@@ -1870,7 +1870,7 @@
             "max_cp": 3281,
             "max_hp": 160,
             "quick_move": "Dragon Tail",
-            "rating": 9.0,
+            "rating": 8,
             "sta": 190,
             "types": [
                 "Flying",
@@ -1885,7 +1885,7 @@
             "max_cp": 2603,
             "max_hp": 215,
             "quick_move": "Water Gun",
-            "rating": 9.0,
+            "rating": 8,
             "sta": 260,
             "types": [
                 "Ice",
@@ -1900,7 +1900,7 @@
             "max_cp": 718,
             "max_hp": 87,
             "quick_move": "Transform",
-            "rating": 0.0,
+            "rating": 2,
             "sta": 96,
             "types": [
                 "Normal"
@@ -1914,7 +1914,7 @@
             "max_cp": 969,
             "max_hp": 98,
             "quick_move": "Tackle",
-            "rating": 4.5,
+            "rating": 3,
             "sta": 110,
             "types": [
                 "Normal"
@@ -1928,7 +1928,7 @@
             "max_cp": 3157,
             "max_hp": 215,
             "quick_move": "Water Gun",
-            "rating": 9.5,
+            "rating": 7.5,
             "sta": 260,
             "types": [
                 "Water"
@@ -1942,7 +1942,7 @@
             "max_cp": 2730,
             "max_hp": 113,
             "quick_move": "Thunder Shock",
-            "rating": 9.0,
+            "rating": 7.5,
             "sta": 130,
             "types": [
                 "Electric"
@@ -1956,7 +1956,7 @@
             "max_cp": 2904,
             "max_hp": 113,
             "quick_move": "Fire Spin",
-            "rating": 8.5,
+            "rating": 7.5,
             "sta": 130,
             "types": [
                 "Fire"
@@ -1970,7 +1970,7 @@
             "max_cp": 1567,
             "max_hp": 113,
             "quick_move": "Tackle",
-            "rating": 4.5,
+            "rating": 4,
             "sta": 130,
             "types": [
                 "Normal"
@@ -1984,7 +1984,7 @@
             "max_cp": 1345,
             "max_hp": 66,
             "quick_move": "Water Gun",
-            "rating": 4.5,
+            "rating": 3.5,
             "sta": 70,
             "types": [
                 "Rock",
@@ -1999,7 +1999,7 @@
             "max_cp": 2685,
             "max_hp": 121,
             "quick_move": "Rock Throw",
-            "rating": 8.5,
+            "rating": 7,
             "sta": 140,
             "types": [
                 "Rock",
@@ -2014,7 +2014,7 @@
             "max_cp": 1172,
             "max_hp": 58,
             "quick_move": "Scratch",
-            "rating": 5.0,
+            "rating": 3.5,
             "sta": 60,
             "types": [
                 "Rock",
@@ -2029,7 +2029,7 @@
             "max_cp": 2517,
             "max_hp": 105,
             "quick_move": "Fury Cutter",
-            "rating": 8.0,
+            "rating": 7,
             "sta": 120,
             "types": [
                 "Rock",
@@ -2059,7 +2059,7 @@
             "max_cp": 3355,
             "max_hp": 262,
             "quick_move": "Lick",
-            "rating": 10.0,
+            "rating": 8,
             "sta": 320,
             "types": [
                 "Normal"
@@ -2073,7 +2073,7 @@
             "max_cp": 2933,
             "max_hp": 153,
             "quick_move": "Frost Breath",
-            "rating": 10.0,
+            "rating": 9.5,
             "sta": 180,
             "types": [
                 "Flying",
@@ -2088,7 +2088,7 @@
             "max_cp": 3330,
             "max_hp": 153,
             "quick_move": "Thunder Shock",
-            "rating": 10.0,
+            "rating": 9.5,
             "sta": 180,
             "types": [
                 "Electric",
@@ -2103,7 +2103,7 @@
             "max_cp": 3272,
             "max_hp": 153,
             "quick_move": "Ember",
-            "rating": 10.0,
+            "rating": 9.5,
             "sta": 180,
             "types": [
                 "Fire",
@@ -2118,7 +2118,7 @@
             "max_cp": 860,
             "max_hp": 76,
             "quick_move": "Dragon Breath",
-            "rating": 4.0,
+            "rating": 2.5,
             "sta": 82,
             "types": [
                 "Dragon"
@@ -2132,7 +2132,7 @@
             "max_cp": 1609,
             "max_hp": 107,
             "quick_move": "Dragon Breath",
-            "rating": 6.0,
+            "rating": 5,
             "sta": 122,
             "types": [
                 "Dragon"
@@ -2146,7 +2146,7 @@
             "max_cp": 3581,
             "max_hp": 154,
             "quick_move": "Dragon Tail",
-            "rating": 9.5,
+            "rating": 10,
             "sta": 182,
             "types": [
                 "Dragon",
@@ -2161,7 +2161,7 @@
             "max_cp": 3982,
             "max_hp": 178,
             "quick_move": "Psycho Cut",
-            "rating": 10.0,
+            "rating": 10,
             "sta": 193,
             "types": [
                 "Psychic"
@@ -2175,7 +2175,7 @@
             "max_cp": 3083,
             "max_hp": 168,
             "quick_move": "Pound",
-            "rating": 10.0,
+            "rating": 10,
             "sta": 200,
             "types": [
                 "Psychic"
@@ -2189,7 +2189,7 @@
             "max_cp": 801,
             "max_hp": 82,
             "quick_move": "Vine Whip",
-            "rating": 3.5,
+            "rating": 2.5,
             "sta": 90,
             "types": [
                 "Grass"
@@ -2203,7 +2203,7 @@
             "max_cp": 1296,
             "max_hp": 105,
             "quick_move": "Razor Leaf",
-            "rating": 5.5,
+            "rating": 4.5,
             "sta": 120,
             "types": [
                 "Grass"
@@ -2217,7 +2217,7 @@
             "max_cp": 2227,
             "max_hp": 137,
             "quick_move": "Vine Whip",
-            "rating": 8.0,
+            "rating": 7.5,
             "sta": 160,
             "types": [
                 "Grass"
@@ -2231,7 +2231,7 @@
             "max_cp": 831,
             "max_hp": 72,
             "quick_move": "Ember",
-            "rating": 3.5,
+            "rating": 2.5,
             "sta": 78,
             "types": [
                 "Fire"
@@ -2245,7 +2245,7 @@
             "max_cp": 1484,
             "max_hp": 102,
             "quick_move": "Ember",
-            "rating": 5.5,
+            "rating": 4.5,
             "sta": 116,
             "types": [
                 "Fire"
@@ -2259,7 +2259,7 @@
             "max_cp": 2686,
             "max_hp": 134,
             "quick_move": "Ember",
-            "rating": 8.0,
+            "rating": 8,
             "sta": 156,
             "types": [
                 "Fire"
@@ -2273,7 +2273,7 @@
             "max_cp": 1011,
             "max_hp": 90,
             "quick_move": "Water Gun",
-            "rating": 3.5,
+            "rating": 2.5,
             "sta": 100,
             "types": [
                 "Water"
@@ -2287,7 +2287,7 @@
             "max_cp": 1598,
             "max_hp": 113,
             "quick_move": "Water Gun",
-            "rating": 5.5,
+            "rating": 4.5,
             "sta": 130,
             "types": [
                 "Water"
@@ -2301,7 +2301,7 @@
             "max_cp": 2721,
             "max_hp": 145,
             "quick_move": "Water Gun",
-            "rating": 8.5,
+            "rating": 8,
             "sta": 170,
             "types": [
                 "Water"
@@ -2315,7 +2315,7 @@
             "max_cp": 519,
             "max_hp": 66,
             "quick_move": "Scratch",
-            "rating": 2.0,
+            "rating": 1,
             "sta": 70,
             "types": [
                 "Normal"
@@ -2329,7 +2329,7 @@
             "max_cp": 1667,
             "max_hp": 145,
             "quick_move": "Quick Attack",
-            "rating": 5.0,
+            "rating": 4.5,
             "sta": 170,
             "types": [
                 "Normal"
@@ -2343,7 +2343,7 @@
             "max_cp": 640,
             "max_hp": 105,
             "quick_move": "Peck",
-            "rating": 3.0,
+            "rating": 1.5,
             "sta": 120,
             "types": [
                 "Flying",
@@ -2358,7 +2358,7 @@
             "max_cp": 2040,
             "max_hp": 168,
             "quick_move": "Wing Attack",
-            "rating": 6.0,
+            "rating": 5.5,
             "sta": 200,
             "types": [
                 "Flying",
@@ -2373,7 +2373,7 @@
             "max_cp": 663,
             "max_hp": 74,
             "quick_move": "Bug Bite",
-            "rating": 3.0,
+            "rating": 2,
             "sta": 80,
             "types": [
                 "Bug",
@@ -2388,7 +2388,7 @@
             "max_cp": 1275,
             "max_hp": 98,
             "quick_move": "Bug Bite",
-            "rating": 4.0,
+            "rating": 4,
             "sta": 110,
             "types": [
                 "Bug",
@@ -2403,7 +2403,7 @@
             "max_cp": 685,
             "max_hp": 74,
             "quick_move": "Bug Bite",
-            "rating": 3.5,
+            "rating": 1.5,
             "sta": 80,
             "types": [
                 "Bug",
@@ -2433,7 +2433,7 @@
             "max_cp": 2466,
             "max_hp": 145,
             "quick_move": "Air Slash",
-            "rating": 7.0,
+            "rating": 8,
             "sta": 170,
             "types": [
                 "Flying",
@@ -2448,7 +2448,7 @@
             "max_cp": 1067,
             "max_hp": 129,
             "quick_move": "Bubble",
-            "rating": 4.0,
+            "rating": 3,
             "sta": 150,
             "types": [
                 "Electric",
@@ -2463,7 +2463,7 @@
             "max_cp": 2077,
             "max_hp": 207,
             "quick_move": "Water Gun",
-            "rating": 6.0,
+            "rating": 6,
             "sta": 250,
             "types": [
                 "Electric",
@@ -2478,7 +2478,7 @@
             "max_cp": 376,
             "max_hp": 43,
             "quick_move": "Thunder Shock",
-            "rating": 3.0,
+            "rating": 1,
             "sta": 40,
             "types": [
                 "Electric"
@@ -2492,7 +2492,7 @@
             "max_cp": 620,
             "max_hp": 90,
             "quick_move": "Pound",
-            "rating": 3.0,
+            "rating": 1,
             "sta": 100,
             "types": [
                 "Fairy"
@@ -2506,7 +2506,7 @@
             "max_cp": 512,
             "max_hp": 153,
             "quick_move": "Pound",
-            "rating": 3.0,
+            "rating": 1,
             "sta": 180,
             "types": [
                 "Fairy",
@@ -2521,7 +2521,7 @@
             "max_cp": 540,
             "max_hp": 66,
             "quick_move": "Zen Headbutt",
-            "rating": 3.0,
+            "rating": 1.5,
             "sta": 70,
             "types": [
                 "Fairy"
@@ -2535,7 +2535,7 @@
             "max_cp": 1543,
             "max_hp": 98,
             "quick_move": "Steel Wing",
-            "rating": 4.0,
+            "rating": 4.5,
             "sta": 110,
             "types": [
                 "Fairy",
@@ -2550,7 +2550,7 @@
             "max_cp": 925,
             "max_hp": 74,
             "quick_move": "Pound",
-            "rating": 4.0,
+            "rating": 2.5,
             "sta": 80,
             "types": [
                 "Flying",
@@ -2565,7 +2565,7 @@
             "max_cp": 1975,
             "max_hp": 113,
             "quick_move": "Air Slash",
-            "rating": 6.0,
+            "rating": 6,
             "sta": 130,
             "types": [
                 "Flying",
@@ -2580,7 +2580,7 @@
             "max_cp": 887,
             "max_hp": 98,
             "quick_move": "Thunder Shock",
-            "rating": 5.0,
+            "rating": 2,
             "sta": 110,
             "types": [
                 "Electric"
@@ -2594,7 +2594,7 @@
             "max_cp": 1402,
             "max_hp": 121,
             "quick_move": "Charge Beam",
-            "rating": 6.0,
+            "rating": 3.5,
             "sta": 140,
             "types": [
                 "Electric"
@@ -2608,7 +2608,7 @@
             "max_cp": 2695,
             "max_hp": 153,
             "quick_move": "Charge Beam",
-            "rating": 8.5,
+            "rating": 7,
             "sta": 180,
             "types": [
                 "Electric"
@@ -2622,7 +2622,7 @@
             "max_cp": 2108,
             "max_hp": 129,
             "quick_move": "Razor Leaf",
-            "rating": 7.0,
+            "rating": 6.5,
             "sta": 150,
             "types": [
                 "Grass"
@@ -2636,7 +2636,7 @@
             "max_cp": 420,
             "max_hp": 121,
             "quick_move": "Bubble",
-            "rating": 3.0,
+            "rating": 1.5,
             "sta": 140,
             "types": [
                 "Fairy",
@@ -2651,7 +2651,7 @@
             "max_cp": 1503,
             "max_hp": 168,
             "quick_move": "Bubble",
-            "rating": 4.0,
+            "rating": 5,
             "sta": 200,
             "types": [
                 "Fairy",
@@ -2666,7 +2666,7 @@
             "max_cp": 2065,
             "max_hp": 121,
             "quick_move": "Rock Throw",
-            "rating": 6.0,
+            "rating": 4.5,
             "sta": 140,
             "types": [
                 "Rock"
@@ -2680,7 +2680,7 @@
             "max_cp": 2371,
             "max_hp": 153,
             "quick_move": "Bubble",
-            "rating": 7.5,
+            "rating": 7,
             "sta": 180,
             "types": [
                 "Water"
@@ -2694,7 +2694,7 @@
             "max_cp": 508,
             "max_hp": 66,
             "quick_move": "Bullet Seed",
-            "rating": 3.0,
+            "rating": 1.5,
             "sta": 70,
             "types": [
                 "Flying",
@@ -2709,7 +2709,7 @@
             "max_cp": 882,
             "max_hp": 98,
             "quick_move": "Bullet Seed",
-            "rating": 4.0,
+            "rating": 3,
             "sta": 110,
             "types": [
                 "Flying",
@@ -2724,7 +2724,7 @@
             "max_cp": 1553,
             "max_hp": 129,
             "quick_move": "Bullet Seed",
-            "rating": 6.0,
+            "rating": 6,
             "sta": 150,
             "types": [
                 "Flying",
@@ -2739,7 +2739,7 @@
             "max_cp": 1188,
             "max_hp": 98,
             "quick_move": "Scratch",
-            "rating": 4.0,
+            "rating": 3.5,
             "sta": 110,
             "types": [
                 "Normal"
@@ -2753,7 +2753,7 @@
             "max_cp": 316,
             "max_hp": 58,
             "quick_move": "Razor Leaf",
-            "rating": 2.0,
+            "rating": 0.5,
             "sta": 60,
             "types": [
                 "Grass"
@@ -2767,7 +2767,7 @@
             "max_cp": 2048,
             "max_hp": 129,
             "quick_move": "Razor Leaf",
-            "rating": 6.0,
+            "rating": 5,
             "sta": 150,
             "types": [
                 "Grass"
@@ -2781,7 +2781,7 @@
             "max_cp": 1326,
             "max_hp": 113,
             "quick_move": "Wing Attack",
-            "rating": 4.0,
+            "rating": 4,
             "sta": 130,
             "types": [
                 "Bug",
@@ -2796,7 +2796,7 @@
             "max_cp": 596,
             "max_hp": 98,
             "quick_move": "Water Gun",
-            "rating": 3.0,
+            "rating": 1,
             "sta": 110,
             "types": [
                 "Ground",
@@ -2811,7 +2811,7 @@
             "max_cp": 1929,
             "max_hp": 160,
             "quick_move": "Water Gun",
-            "rating": 6.0,
+            "rating": 5,
             "sta": 190,
             "types": [
                 "Ground",
@@ -2826,7 +2826,7 @@
             "max_cp": 3000,
             "max_hp": 113,
             "quick_move": "Confusion",
-            "rating": 8.5,
+            "rating": 7.5,
             "sta": 130,
             "types": [
                 "Psychic"
@@ -2854,7 +2854,7 @@
             "max_cp": 1392,
             "max_hp": 105,
             "quick_move": "Feint Attack",
-            "rating": 5.0,
+            "rating": 4.5,
             "sta": 120,
             "types": [
                 "Dark",
@@ -2869,7 +2869,7 @@
             "max_cp": 2482,
             "max_hp": 160,
             "quick_move": "Confusion",
-            "rating": 8.5,
+            "rating": 6.5,
             "sta": 190,
             "types": [
                 "Psychic",
@@ -2884,7 +2884,7 @@
             "max_cp": 1781,
             "max_hp": 105,
             "quick_move": "Hex",
-            "rating": 7.0,
+            "rating": 5,
             "sta": 120,
             "types": [
                 "Ghost"
@@ -2898,7 +2898,7 @@
             "max_cp": 1022,
             "max_hp": 87,
             "quick_move": "Hidden Power",
-            "rating": 5.0,
+            "rating": 3,
             "sta": 96,
             "types": [
                 "Psychic"
@@ -2912,7 +2912,7 @@
             "max_cp": 1024,
             "max_hp": 309,
             "quick_move": "Counter",
-            "rating": 5.0,
+            "rating": 4.5,
             "sta": 380,
             "types": [
                 "Psychic"
@@ -2926,7 +2926,7 @@
             "max_cp": 1863,
             "max_hp": 121,
             "quick_move": "Confusion",
-            "rating": 7.0,
+            "rating": 5.5,
             "sta": 140,
             "types": [
                 "Normal",
@@ -2941,7 +2941,7 @@
             "max_cp": 1045,
             "max_hp": 90,
             "quick_move": "Bug Bite",
-            "rating": 5.0,
+            "rating": 2,
             "sta": 100,
             "types": [
                 "Bug"
@@ -2955,7 +2955,7 @@
             "max_cp": 2263,
             "max_hp": 129,
             "quick_move": "Bug Bite",
-            "rating": 7.0,
+            "rating": 6,
             "sta": 150,
             "types": [
                 "Bug",
@@ -2970,7 +2970,7 @@
             "max_cp": 1615,
             "max_hp": 168,
             "quick_move": "Bite",
-            "rating": 6.5,
+            "rating": 4.5,
             "sta": 200,
             "types": [
                 "Normal"
@@ -2984,7 +2984,7 @@
             "max_cp": 1758,
             "max_hp": 113,
             "quick_move": "Wing Attack",
-            "rating": 6.5,
+            "rating": 5,
             "sta": 130,
             "types": [
                 "Flying",
@@ -2999,7 +2999,7 @@
             "max_cp": 2439,
             "max_hp": 129,
             "quick_move": "Iron Tail",
-            "rating": 8.5,
+            "rating": 7,
             "sta": 150,
             "types": [
                 "Ground",
@@ -3014,7 +3014,7 @@
             "max_cp": 1124,
             "max_hp": 105,
             "quick_move": "Bite",
-            "rating": 4.5,
+            "rating": 2.5,
             "sta": 120,
             "types": [
                 "Fairy"
@@ -3028,7 +3028,7 @@
             "max_cp": 2440,
             "max_hp": 153,
             "quick_move": "Bite",
-            "rating": 7.5,
+            "rating": 5.5,
             "sta": 180,
             "types": [
                 "Fairy"
@@ -3042,7 +3042,7 @@
             "max_cp": 1910,
             "max_hp": 113,
             "quick_move": "Water Gun",
-            "rating": 7.5,
+            "rating": 5.5,
             "sta": 130,
             "types": [
                 "Poison",
@@ -3057,7 +3057,7 @@
             "max_cp": 2801,
             "max_hp": 121,
             "quick_move": "Bullet Punch",
-            "rating": 8.0,
+            "rating": 7,
             "sta": 140,
             "types": [
                 "Bug",
@@ -3072,7 +3072,7 @@
             "max_cp": 300,
             "max_hp": 43,
             "quick_move": "Rock Throw",
-            "rating": 3.0,
+            "rating": 7,
             "sta": 40,
             "types": [
                 "Bug",
@@ -3087,7 +3087,7 @@
             "max_cp": 2938,
             "max_hp": 137,
             "quick_move": "Counter",
-            "rating": 9.0,
+            "rating": 7,
             "sta": 160,
             "types": [
                 "Bug",
@@ -3102,7 +3102,7 @@
             "max_cp": 1868,
             "max_hp": 98,
             "quick_move": "Feint Attack",
-            "rating": 7.0,
+            "rating": 5,
             "sta": 110,
             "types": [
                 "Dark",
@@ -3117,7 +3117,7 @@
             "max_cp": 1184,
             "max_hp": 105,
             "quick_move": "Scratch",
-            "rating": 5.0,
+            "rating": 3,
             "sta": 120,
             "types": [
                 "Normal"
@@ -3131,7 +3131,7 @@
             "max_cp": 2760,
             "max_hp": 153,
             "quick_move": "Counter",
-            "rating": 8.0,
+            "rating": 7,
             "sta": 180,
             "types": [
                 "Normal"
@@ -3145,7 +3145,7 @@
             "max_cp": 750,
             "max_hp": 74,
             "quick_move": "Ember",
-            "rating": 4.0,
+            "rating": 1.5,
             "sta": 80,
             "types": [
                 "Fire"
@@ -3159,7 +3159,7 @@
             "max_cp": 1543,
             "max_hp": 90,
             "quick_move": "Ember",
-            "rating": 5.0,
+            "rating": 5,
             "sta": 100,
             "types": [
                 "Fire",
@@ -3174,7 +3174,7 @@
             "max_cp": 663,
             "max_hp": 90,
             "quick_move": "Powder Snow",
-            "rating": 4.0,
+            "rating": 1.5,
             "sta": 100,
             "types": [
                 "Ground",
@@ -3189,7 +3189,7 @@
             "max_cp": 2284,
             "max_hp": 168,
             "quick_move": "Ice Shard",
-            "rating": 6.5,
+            "rating": 5.5,
             "sta": 200,
             "types": [
                 "Ground",
@@ -3204,7 +3204,7 @@
             "max_cp": 1214,
             "max_hp": 98,
             "quick_move": "Bubble",
-            "rating": 5.0,
+            "rating": 4.5,
             "sta": 110,
             "types": [
                 "Rock",
@@ -3219,7 +3219,7 @@
             "max_cp": 749,
             "max_hp": 66,
             "quick_move": "Water Gun",
-            "rating": 4.0,
+            "rating": 2.5,
             "sta": 70,
             "types": [
                 "Water"
@@ -3233,7 +3233,7 @@
             "max_cp": 2124,
             "max_hp": 129,
             "quick_move": "Water Gun",
-            "rating": 7.0,
+            "rating": 6.5,
             "sta": 150,
             "types": [
                 "Water"
@@ -3247,7 +3247,7 @@
             "max_cp": 937,
             "max_hp": 82,
             "quick_move": "Ice Shard",
-            "rating": 4.5,
+            "rating": 3,
             "sta": 90,
             "types": [
                 "Flying",
@@ -3262,7 +3262,7 @@
             "max_cp": 2032,
             "max_hp": 113,
             "quick_move": "Wing Attack",
-            "rating": 7.0,
+            "rating": 6.5,
             "sta": 130,
             "types": [
                 "Flying",
@@ -3277,7 +3277,7 @@
             "max_cp": 2032,
             "max_hp": 113,
             "quick_move": "Steel Wing",
-            "rating": 7.0,
+            "rating": 6,
             "sta": 130,
             "types": [
                 "Flying",
@@ -3292,7 +3292,7 @@
             "max_cp": 1110,
             "max_hp": 82,
             "quick_move": "Feint Attack",
-            "rating": 5.0,
+            "rating": 3,
             "sta": 90,
             "types": [
                 "Dark",
@@ -3307,7 +3307,7 @@
             "max_cp": 2529,
             "max_hp": 129,
             "quick_move": "Snarl",
-            "rating": 7.5,
+            "rating": 7,
             "sta": 150,
             "types": [
                 "Dark",
@@ -3322,7 +3322,7 @@
             "max_cp": 2424,
             "max_hp": 129,
             "quick_move": "Dragon Breath",
-            "rating": 7.5,
+            "rating": 8,
             "sta": 150,
             "types": [
                 "Dragon",
@@ -3337,7 +3337,7 @@
             "max_cp": 1175,
             "max_hp": 153,
             "quick_move": "Rock Smash",
-            "rating": 5.0,
+            "rating": 3,
             "sta": 180,
             "types": [
                 "Ground"
@@ -3351,7 +3351,7 @@
             "max_cp": 3022,
             "max_hp": 153,
             "quick_move": "Counter",
-            "rating": 9.0,
+            "rating": 7,
             "sta": 180,
             "types": [
                 "Ground"
@@ -3379,7 +3379,7 @@
             "max_cp": 1988,
             "max_hp": 126,
             "quick_move": "Tackle",
-            "rating": 6.5,
+            "rating": 6,
             "sta": 146,
             "types": [
                 "Normal"
@@ -3393,7 +3393,7 @@
             "max_cp": 389,
             "max_hp": 98,
             "quick_move": "Tackle",
-            "rating": 2.0,
+            "rating": 1.5,
             "sta": 110,
             "types": [
                 "Normal"
@@ -3407,7 +3407,7 @@
             "max_cp": 404,
             "max_hp": 66,
             "quick_move": "Rock Smash",
-            "rating": 3.0,
+            "rating": 1,
             "sta": 70,
             "types": [
                 "Fighting"
@@ -3421,7 +3421,7 @@
             "max_cp": 1905,
             "max_hp": 90,
             "quick_move": "Counter",
-            "rating": 6.5,
+            "rating": 5.5,
             "sta": 100,
             "types": [
                 "Fighting"
@@ -3435,7 +3435,7 @@
             "max_cp": 1230,
             "max_hp": 82,
             "quick_move": "Pound",
-            "rating": 4.0,
+            "rating": 2.5,
             "sta": 90,
             "types": [
                 "Ice",
@@ -3450,7 +3450,7 @@
             "max_cp": 1073,
             "max_hp": 82,
             "quick_move": "Thunder Shock",
-            "rating": 4.0,
+            "rating": 3.5,
             "sta": 90,
             "types": [
                 "Electric"
@@ -3464,7 +3464,7 @@
             "max_cp": 1178,
             "max_hp": 82,
             "quick_move": "Ember",
-            "rating": 4.0,
+            "rating": 3.5,
             "sta": 90,
             "types": [
                 "Fire"
@@ -3478,7 +3478,7 @@
             "max_cp": 2312,
             "max_hp": 160,
             "quick_move": "Tackle",
-            "rating": 7.5,
+            "rating": 6.5,
             "sta": 190,
             "types": [
                 "Normal"
@@ -3492,7 +3492,7 @@
             "max_cp": 3219,
             "max_hp": 415,
             "quick_move": "Pound",
-            "rating": 10.0,
+            "rating": 8,
             "sta": 510,
             "types": [
                 "Normal"
@@ -3520,7 +3520,7 @@
             "max_cp": 3412,
             "max_hp": 192,
             "quick_move": "Fire Spin",
-            "rating": 9.0,
+            "rating": 9.5,
             "sta": 230,
             "types": [
                 "Fire"
@@ -3534,7 +3534,7 @@
             "max_cp": 2823,
             "max_hp": 168,
             "quick_move": "Hidden Power",
-            "rating": 8.5,
+            "rating": 9.5,
             "sta": 200,
             "types": [
                 "Water"
@@ -3548,7 +3548,7 @@
             "max_cp": 904,
             "max_hp": 90,
             "quick_move": "Bite",
-            "rating": 5.0,
+            "rating": 2.5,
             "sta": 100,
             "types": [
                 "Ground",
@@ -3563,7 +3563,7 @@
             "max_cp": 1608,
             "max_hp": 121,
             "quick_move": "Bite",
-            "rating": 7.0,
+            "rating": 4.5,
             "sta": 140,
             "types": [
                 "Ground",
@@ -3578,7 +3578,7 @@
             "max_cp": 3670,
             "max_hp": 168,
             "quick_move": "Bite",
-            "rating": 9.5,
+            "rating": 10,
             "sta": 200,
             "types": [
                 "Dark",
@@ -3593,7 +3593,7 @@
             "max_cp": 3598,
             "max_hp": 178,
             "quick_move": "Extrasensory",
-            "rating": 10.0,
+            "rating": 10,
             "sta": 212,
             "types": [
                 "Flying",
@@ -3608,7 +3608,7 @@
             "max_cp": 4650,
             "max_hp": 178,
             "quick_move": "Steel Wing",
-            "rating": 10.0,
+            "rating": 10,
             "sta": 212,
             "types": [
                 "Fire",
@@ -3623,7 +3623,7 @@
             "max_cp": 3090,
             "max_hp": 168,
             "quick_move": "Confusion",
-            "rating": 10.0,
+            "rating": 10,
             "sta": 200,
             "types": [
                 "Grass",
@@ -3638,7 +3638,7 @@
             "max_cp": 923,
             "max_hp": 75,
             "quick_move": "Pound",
-            "rating": 1.0,
+            "rating": 2.5,
             "sta": 80,
             "types": [
                 "Grass"
@@ -3652,7 +3652,7 @@
             "max_cp": 1508,
             "max_hp": 91,
             "quick_move": "Quick Attack",
-            "rating": 1.0,
+            "rating": 4.5,
             "sta": 100,
             "types": [
                 "Grass"
@@ -3666,7 +3666,7 @@
             "max_cp": 2584,
             "max_hp": 122,
             "quick_move": "Fury Cutter",
-            "rating": 1.0,
+            "rating": 8,
             "sta": 140,
             "types": [
                 "Grass"
@@ -3680,7 +3680,7 @@
             "max_cp": 959,
             "max_hp": 83,
             "quick_move": "Ember",
-            "rating": 1.0,
+            "rating": 2.5,
             "sta": 90,
             "types": [
                 "Fire"
@@ -3694,7 +3694,7 @@
             "max_cp": 1472,
             "max_hp": 107,
             "quick_move": "Ember",
-            "rating": 1.0,
+            "rating": 4.5,
             "sta": 120,
             "types": [
                 "Fire",
@@ -3709,7 +3709,7 @@
             "max_cp": 2631,
             "max_hp": 138,
             "quick_move": "Counter",
-            "rating": 1.0,
+            "rating": 8,
             "sta": 160,
             "types": [
                 "Fire",
@@ -3724,7 +3724,7 @@
             "max_cp": 981,
             "max_hp": 91,
             "quick_move": "Water Gun",
-            "rating": 1.0,
+            "rating": 2.5,
             "sta": 100,
             "types": [
                 "Water"
@@ -3738,7 +3738,7 @@
             "max_cp": 1617,
             "max_hp": 122,
             "quick_move": "Water Gun",
-            "rating": 1.0,
+            "rating": 4.5,
             "sta": 140,
             "types": [
                 "Water",
@@ -3753,7 +3753,7 @@
             "max_cp": 2815,
             "max_hp": 170,
             "quick_move": "Water Gun",
-            "rating": 1.0,
+            "rating": 8,
             "sta": 200,
             "types": [
                 "Water",
@@ -3768,7 +3768,7 @@
             "max_cp": 564,
             "max_hp": 67,
             "quick_move": "Snarl",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 70,
             "types": [
                 "Dark"
@@ -3782,7 +3782,7 @@
             "max_cp": 1783,
             "max_hp": 122,
             "quick_move": "Bite",
-            "rating": 1.0,
+            "rating": 5,
             "sta": 140,
             "types": [
                 "Dark"
@@ -3796,7 +3796,7 @@
             "max_cp": 423,
             "max_hp": 72,
             "quick_move": "Tackle",
-            "rating": 1.0,
+            "rating": 1.5,
             "sta": 76,
             "types": [
                 "Normal"
@@ -3810,7 +3810,7 @@
             "max_cp": 1533,
             "max_hp": 135,
             "quick_move": "Shadow Claw",
-            "rating": 1.0,
+            "rating": 5,
             "sta": 156,
             "types": [
                 "Normal"
@@ -3824,7 +3824,7 @@
             "max_cp": 502,
             "max_hp": 83,
             "quick_move": "Bug Bite",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 90,
             "types": [
                 "Bug"
@@ -3838,7 +3838,7 @@
             "max_cp": 517,
             "max_hp": 91,
             "quick_move": "Bug Bite",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 100,
             "types": [
                 "Bug"
@@ -3852,7 +3852,7 @@
             "max_cp": 1573,
             "max_hp": 107,
             "quick_move": "Infestation",
-            "rating": 1.0,
+            "rating": 4,
             "sta": 120,
             "types": [
                 "Bug",
@@ -3867,7 +3867,7 @@
             "max_cp": 517,
             "max_hp": 91,
             "quick_move": "Bug Bite",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 100,
             "types": [
                 "Bug"
@@ -3881,7 +3881,7 @@
             "max_cp": 1121,
             "max_hp": 107,
             "quick_move": "Confusion",
-            "rating": 1.0,
+            "rating": 4,
             "sta": 120,
             "types": [
                 "Bug",
@@ -3896,7 +3896,7 @@
             "max_cp": 526,
             "max_hp": 75,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 80,
             "types": [
                 "Water",
@@ -3911,7 +3911,7 @@
             "max_cp": 1102,
             "max_hp": 107,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 3,
             "sta": 120,
             "types": [
                 "Water",
@@ -3926,7 +3926,7 @@
             "max_cp": 2229,
             "max_hp": 138,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 6.5,
             "sta": 160,
             "types": [
                 "Water",
@@ -3941,7 +3941,7 @@
             "max_cp": 526,
             "max_hp": 75,
             "quick_move": "Quick Attack",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 80,
             "types": [
                 "Grass"
@@ -3955,7 +3955,7 @@
             "max_cp": 1117,
             "max_hp": 122,
             "quick_move": "Feint Attack",
-            "rating": 1.0,
+            "rating": 3,
             "sta": 140,
             "types": [
                 "Grass",
@@ -3970,7 +3970,7 @@
             "max_cp": 2186,
             "max_hp": 154,
             "quick_move": "Razor Leaf",
-            "rating": 1.0,
+            "rating": 6.5,
             "sta": 180,
             "types": [
                 "Grass",
@@ -3985,7 +3985,7 @@
             "max_cp": 642,
             "max_hp": 75,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 2,
             "sta": 80,
             "types": [
                 "Normal",
@@ -4000,7 +4000,7 @@
             "max_cp": 1747,
             "max_hp": 107,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 5.5,
             "sta": 120,
             "types": [
                 "Normal",
@@ -4015,7 +4015,7 @@
             "max_cp": 642,
             "max_hp": 75,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 2,
             "sta": 80,
             "types": [
                 "Water",
@@ -4030,7 +4030,7 @@
             "max_cp": 1969,
             "max_hp": 107,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 5.5,
             "sta": 120,
             "types": [
                 "Water",
@@ -4045,7 +4045,7 @@
             "max_cp": 436,
             "max_hp": 56,
             "quick_move": "Confusion",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 56,
             "types": [
                 "Psychic",
@@ -4060,7 +4060,7 @@
             "max_cp": 843,
             "max_hp": 72,
             "quick_move": "Confusion",
-            "rating": 1.0,
+            "rating": 2,
             "sta": 76,
             "types": [
                 "Psychic",
@@ -4075,7 +4075,7 @@
             "max_cp": 2964,
             "max_hp": 119,
             "quick_move": "Confusion",
-            "rating": 1.0,
+            "rating": 7.5,
             "sta": 136,
             "types": [
                 "Psychic",
@@ -4090,7 +4090,7 @@
             "max_cp": 695,
             "max_hp": 75,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 2,
             "sta": 80,
             "types": [
                 "Bug",
@@ -4105,7 +4105,7 @@
             "max_cp": 2135,
             "max_hp": 122,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 5.5,
             "sta": 140,
             "types": [
                 "Bug",
@@ -4120,7 +4120,7 @@
             "max_cp": 722,
             "max_hp": 107,
             "quick_move": "Bullet Seed",
-            "rating": 1.0,
+            "rating": 2,
             "sta": 120,
             "types": [
                 "Grass"
@@ -4134,7 +4134,7 @@
             "max_cp": 2407,
             "max_hp": 107,
             "quick_move": "Counter",
-            "rating": 1.0,
+            "rating": 6,
             "sta": 120,
             "types": [
                 "Grass",
@@ -4149,7 +4149,7 @@
             "max_cp": 942,
             "max_hp": 107,
             "quick_move": "Yawn",
-            "rating": 1.0,
+            "rating": 2,
             "sta": 120,
             "types": [
                 "Normal"
@@ -4163,7 +4163,7 @@
             "max_cp": 1896,
             "max_hp": 138,
             "quick_move": "Scratch",
-            "rating": 1.0,
+            "rating": 5.5,
             "sta": 160,
             "types": [
                 "Normal"
@@ -4177,7 +4177,7 @@
             "max_cp": 4548,
             "max_hp": 249,
             "quick_move": "Yawn",
-            "rating": 1.0,
+            "rating": 10,
             "sta": 300,
             "types": [
                 "Normal"
@@ -4191,7 +4191,7 @@
             "max_cp": 674,
             "max_hp": 61,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 2,
             "sta": 62,
             "types": [
                 "Bug",
@@ -4206,7 +4206,7 @@
             "max_cp": 1790,
             "max_hp": 108,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 5.5,
             "sta": 122,
             "types": [
                 "Bug",
@@ -4221,7 +4221,7 @@
             "max_cp": 421,
             "max_hp": 13,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1.5,
             "sta": 2,
             "types": [
                 "Bug",
@@ -4236,7 +4236,7 @@
             "max_cp": 603,
             "max_hp": 113,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1.5,
             "sta": 128,
             "types": [
                 "Normal"
@@ -4250,7 +4250,7 @@
             "max_cp": 1233,
             "max_hp": 145,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 3.5,
             "sta": 168,
             "types": [
                 "Normal"
@@ -4264,7 +4264,7 @@
             "max_cp": 2267,
             "max_hp": 176,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 6.5,
             "sta": 208,
             "types": [
                 "Normal"
@@ -4278,7 +4278,7 @@
             "max_cp": 745,
             "max_hp": 126,
             "quick_move": "Rock Smash",
-            "rating": 1.0,
+            "rating": 1.5,
             "sta": 144,
             "types": [
                 "Fighting"
@@ -4292,7 +4292,7 @@
             "max_cp": 2765,
             "max_hp": 239,
             "quick_move": "Counter",
-            "rating": 1.0,
+            "rating": 6,
             "sta": 288,
             "types": [
                 "Fighting"
@@ -4306,7 +4306,7 @@
             "max_cp": 316,
             "max_hp": 91,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 100,
             "types": [
                 "Normal",
@@ -4321,7 +4321,7 @@
             "max_cp": 831,
             "max_hp": 59,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 4,
             "sta": 60,
             "types": [
                 "Rock"
@@ -4335,7 +4335,7 @@
             "max_cp": 659,
             "max_hp": 91,
             "quick_move": "Tackle",
-            "rating": 1.0,
+            "rating": 1.5,
             "sta": 100,
             "types": [
                 "Normal"
@@ -4349,7 +4349,7 @@
             "max_cp": 1385,
             "max_hp": 122,
             "quick_move": "Feint Attack",
-            "rating": 1.0,
+            "rating": 4.5,
             "sta": 140,
             "types": [
                 "Normal"
@@ -4363,7 +4363,7 @@
             "max_cp": 1305,
             "max_hp": 91,
             "quick_move": "Shadow Claw",
-            "rating": 1.0,
+            "rating": 4,
             "sta": 100,
             "types": [
                 "Dark",
@@ -4378,7 +4378,7 @@
             "max_cp": 1484,
             "max_hp": 1,
             "quick_move": "Bite",
-            "rating": 1.0,
+            "rating": 4,
             "sta": 100,
             "types": [
                 "Steel",
@@ -4393,7 +4393,7 @@
             "max_cp": 1232,
             "max_hp": 91,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 3,
             "sta": 100,
             "types": [
                 "Steel",
@@ -4408,7 +4408,7 @@
             "max_cp": 2004,
             "max_hp": 107,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 5,
             "sta": 120,
             "types": [
                 "Steel",
@@ -4423,7 +4423,7 @@
             "max_cp": 3004,
             "max_hp": 122,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 8,
             "sta": 140,
             "types": [
                 "Steel",
@@ -4438,7 +4438,7 @@
             "max_cp": 555,
             "max_hp": 59,
             "quick_move": "Confusion",
-            "rating": 1.0,
+            "rating": 2,
             "sta": 60,
             "types": [
                 "Fighting",
@@ -4453,7 +4453,7 @@
             "max_cp": 1275,
             "max_hp": 107,
             "quick_move": "Counter",
-            "rating": 1.0,
+            "rating": 4.5,
             "sta": 120,
             "types": [
                 "Fighting",
@@ -4468,7 +4468,7 @@
             "max_cp": 810,
             "max_hp": 75,
             "quick_move": "Spark",
-            "rating": 1.0,
+            "rating": 2,
             "sta": 80,
             "types": [
                 "Electric"
@@ -4482,7 +4482,7 @@
             "max_cp": 2131,
             "max_hp": 122,
             "quick_move": "Charge Beam",
-            "rating": 1.0,
+            "rating": 6,
             "sta": 140,
             "types": [
                 "Electric"
@@ -4496,7 +4496,7 @@
             "max_cp": 1681,
             "max_hp": 107,
             "quick_move": "Spark",
-            "rating": 1.0,
+            "rating": 4.5,
             "sta": 120,
             "types": [
                 "Electric"
@@ -4510,7 +4510,7 @@
             "max_cp": 1585,
             "max_hp": 107,
             "quick_move": "Spark",
-            "rating": 1.0,
+            "rating": 4.5,
             "sta": 120,
             "types": [
                 "Electric"
@@ -4524,7 +4524,7 @@
             "max_cp": 1620,
             "max_hp": 115,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 5,
             "sta": 130,
             "types": [
                 "Bug"
@@ -4538,7 +4538,7 @@
             "max_cp": 1620,
             "max_hp": 115,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 5,
             "sta": 130,
             "types": [
                 "Bug"
@@ -4552,7 +4552,7 @@
             "max_cp": 1718,
             "max_hp": 91,
             "quick_move": "Poison Jab",
-            "rating": 1.0,
+            "rating": 4.5,
             "sta": 100,
             "types": [
                 "Grass",
@@ -4567,7 +4567,7 @@
             "max_cp": 788,
             "max_hp": 122,
             "quick_move": "Pound",
-            "rating": 1.0,
+            "rating": 2.5,
             "sta": 140,
             "types": [
                 "Poison"
@@ -4581,7 +4581,7 @@
             "max_cp": 1872,
             "max_hp": 170,
             "quick_move": "Infestation",
-            "rating": 1.0,
+            "rating": 6,
             "sta": 200,
             "types": [
                 "Poison"
@@ -4595,7 +4595,7 @@
             "max_cp": 874,
             "max_hp": 83,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 2.5,
             "sta": 90,
             "types": [
                 "Water",
@@ -4610,7 +4610,7 @@
             "max_cp": 1986,
             "max_hp": 122,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 6,
             "sta": 140,
             "types": [
                 "Water",
@@ -4625,7 +4625,7 @@
             "max_cp": 1424,
             "max_hp": 217,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 4.5,
             "sta": 260,
             "types": [
                 "Water"
@@ -4639,7 +4639,7 @@
             "max_cp": 2258,
             "max_hp": 281,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 7,
             "sta": 340,
             "types": [
                 "Water"
@@ -4653,7 +4653,7 @@
             "max_cp": 957,
             "max_hp": 107,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 2.5,
             "sta": 120,
             "types": [
                 "Fire",
@@ -4668,7 +4668,7 @@
             "max_cp": 2016,
             "max_hp": 122,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 6,
             "sta": 140,
             "types": [
                 "Fire",
@@ -4683,7 +4683,7 @@
             "max_cp": 2036,
             "max_hp": 122,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 6,
             "sta": 140,
             "types": [
                 "Fire"
@@ -4697,7 +4697,7 @@
             "max_cp": 1285,
             "max_hp": 107,
             "quick_move": "Zen Headbutt",
-            "rating": 1.0,
+            "rating": 3,
             "sta": 120,
             "types": [
                 "Psychic"
@@ -4711,7 +4711,7 @@
             "max_cp": 2310,
             "max_hp": 138,
             "quick_move": "Extrasensory",
-            "rating": 1.0,
+            "rating": 6,
             "sta": 160,
             "types": [
                 "Psychic"
@@ -4725,7 +4725,7 @@
             "max_cp": 1088,
             "max_hp": 107,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 3.5,
             "sta": 120,
             "types": [
                 "Normal"
@@ -4739,7 +4739,7 @@
             "max_cp": 1092,
             "max_hp": 83,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 2,
             "sta": 90,
             "types": [
                 "Ground"
@@ -4753,7 +4753,7 @@
             "max_cp": 1065,
             "max_hp": 91,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 3,
             "sta": 100,
             "types": [
                 "Ground",
@@ -4768,7 +4768,7 @@
             "max_cp": 2458,
             "max_hp": 138,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 7.5,
             "sta": 160,
             "types": [
                 "Ground",
@@ -4783,7 +4783,7 @@
             "max_cp": 1080,
             "max_hp": 91,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 3,
             "sta": 100,
             "types": [
                 "Grass"
@@ -4797,7 +4797,7 @@
             "max_cp": 2092,
             "max_hp": 122,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 6,
             "sta": 140,
             "types": [
                 "Grass",
@@ -4812,7 +4812,7 @@
             "max_cp": 722,
             "max_hp": 83,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 2.5,
             "sta": 90,
             "types": [
                 "Normal",
@@ -4827,7 +4827,7 @@
             "max_cp": 1868,
             "max_hp": 130,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 6.5,
             "sta": 150,
             "types": [
                 "Dragon",
@@ -4842,7 +4842,7 @@
             "max_cp": 2214,
             "max_hp": 127,
             "quick_move": "Shadow Claw",
-            "rating": 1.0,
+            "rating": 5.5,
             "sta": 146,
             "types": [
                 "Normal"
@@ -4856,7 +4856,7 @@
             "max_cp": 2245,
             "max_hp": 127,
             "quick_move": "Poison Jab",
-            "rating": 1.0,
+            "rating": 5.5,
             "sta": 180,
             "types": [
                 "Poison"
@@ -4870,7 +4870,7 @@
             "max_cp": 2122,
             "max_hp": 154,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 6,
             "sta": 180,
             "types": [
                 "Rock",
@@ -4885,7 +4885,7 @@
             "max_cp": 2245,
             "max_hp": 154,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 6,
             "sta": 180,
             "types": [
                 "Rock",
@@ -4900,7 +4900,7 @@
             "max_cp": 716,
             "max_hp": 191,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 2,
             "sta": 100,
             "types": [
                 "Water",
@@ -4915,7 +4915,7 @@
             "max_cp": 1991,
             "max_hp": 186,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 6,
             "sta": 220,
             "types": [
                 "Water",
@@ -4930,7 +4930,7 @@
             "max_cp": 1107,
             "max_hp": 80,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 2.5,
             "sta": 86,
             "types": [
                 "Water"
@@ -4944,7 +4944,7 @@
             "max_cp": 2317,
             "max_hp": 111,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 6,
             "sta": 126,
             "types": [
                 "Water",
@@ -4959,7 +4959,7 @@
             "max_cp": 676,
             "max_hp": 75,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 2.5,
             "sta": 80,
             "types": [
                 "Ground",
@@ -4974,7 +4974,7 @@
             "max_cp": 1782,
             "max_hp": 107,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 7,
             "sta": 120,
             "types": [
                 "Ground",
@@ -4989,7 +4989,7 @@
             "max_cp": 1181,
             "max_hp": 116,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 3.5,
             "sta": 132,
             "types": [
                 "Rock",
@@ -5004,7 +5004,7 @@
             "max_cp": 2081,
             "max_hp": 148,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 7,
             "sta": 172,
             "types": [
                 "Rock",
@@ -5019,7 +5019,7 @@
             "max_cp": 1310,
             "max_hp": 83,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 3.5,
             "sta": 90,
             "types": [
                 "Rock",
@@ -5034,7 +5034,7 @@
             "max_cp": 2675,
             "max_hp": 130,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 7,
             "sta": 150,
             "types": [
                 "Rock",
@@ -5049,7 +5049,7 @@
             "max_cp": 220,
             "max_hp": 43,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 40,
             "types": [
                 "Water"
@@ -5063,7 +5063,7 @@
             "max_cp": 2967,
             "max_hp": 162,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 8,
             "sta": 190,
             "types": [
                 "Water"
@@ -5077,7 +5077,7 @@
             "max_cp": 1486,
             "max_hp": 122,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 5,
             "sta": 140,
             "types": [
                 "Normal"
@@ -5091,7 +5091,7 @@
             "max_cp": 1924,
             "max_hp": 107,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 5.5,
             "sta": 120,
             "types": [
                 "Normal"
@@ -5105,7 +5105,7 @@
             "max_cp": 872,
             "max_hp": 81,
             "quick_move": "Feint Attack",
-            "rating": 1.0,
+            "rating": 2,
             "sta": 88,
             "types": [
                 "Ghost"
@@ -5119,7 +5119,7 @@
             "max_cp": 2073,
             "max_hp": 113,
             "quick_move": "Shadow Claw",
-            "rating": 1.0,
+            "rating": 5.5,
             "sta": 128,
             "types": [
                 "Ghost"
@@ -5133,7 +5133,7 @@
             "max_cp": 523,
             "max_hp": 43,
             "quick_move": "Hex",
-            "rating": 1.0,
+            "rating": 2,
             "sta": 40,
             "types": [
                 "Ghost"
@@ -5147,7 +5147,7 @@
             "max_cp": 1335,
             "max_hp": 75,
             "quick_move": "Feint Attack",
-            "rating": 1.0,
+            "rating": 5.5,
             "sta": 80,
             "types": [
                 "Ghost"
@@ -5161,7 +5161,7 @@
             "max_cp": 1846,
             "max_hp": 168,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 6,
             "sta": 198,
             "types": [
                 "Grass",
@@ -5176,7 +5176,7 @@
             "max_cp": 2095,
             "max_hp": 130,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 5.5,
             "sta": 150,
             "types": [
                 "Psychic"
@@ -5190,7 +5190,7 @@
             "max_cp": 2280,
             "max_hp": 115,
             "quick_move": "Snarl",
-            "rating": 1.0,
+            "rating": 6,
             "sta": 130,
             "types": [
                 "Dark"
@@ -5204,7 +5204,7 @@
             "max_cp": 503,
             "max_hp": 162,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1.5,
             "sta": 190,
             "types": [
                 "Psychic"
@@ -5218,7 +5218,7 @@
             "max_cp": 772,
             "max_hp": 91,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 2.5,
             "sta": 100,
             "types": [
                 "Ice"
@@ -5232,7 +5232,7 @@
             "max_cp": 1945,
             "max_hp": 138,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 6.5,
             "sta": 160,
             "types": [
                 "Ice"
@@ -5246,7 +5246,7 @@
             "max_cp": 876,
             "max_hp": 122,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 2,
             "sta": 140,
             "types": [
                 "Ice",
@@ -5261,7 +5261,7 @@
             "max_cp": 1607,
             "max_hp": 154,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 4.5,
             "sta": 180,
             "types": [
                 "Ice",
@@ -5276,7 +5276,7 @@
             "max_cp": 2606,
             "max_hp": 186,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 8,
             "sta": 220,
             "types": [
                 "Ice",
@@ -5291,7 +5291,7 @@
             "max_cp": 1091,
             "max_hp": 67,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 3,
             "sta": 70,
             "types": [
                 "Water"
@@ -5305,7 +5305,7 @@
             "max_cp": 2140,
             "max_hp": 99,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 6.5,
             "sta": 110,
             "types": [
                 "Water"
@@ -5319,7 +5319,7 @@
             "max_cp": 2281,
             "max_hp": 99,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 6.5,
             "sta": 110,
             "types": [
                 "Water"
@@ -5333,7 +5333,7 @@
             "max_cp": 2557,
             "max_hp": 170,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 6.5,
             "sta": 200,
             "types": [
                 "Water",
@@ -5348,7 +5348,7 @@
             "max_cp": 735,
             "max_hp": 80,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 3,
             "sta": 86,
             "types": [
                 "Water"
@@ -5362,7 +5362,7 @@
             "max_cp": 1053,
             "max_hp": 83,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 2.5,
             "sta": 90,
             "types": [
                 "Dragon"
@@ -5376,7 +5376,7 @@
             "max_cp": 1958,
             "max_hp": 115,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 5,
             "sta": 130,
             "types": [
                 "Dragon"
@@ -5390,7 +5390,7 @@
             "max_cp": 3532,
             "max_hp": 162,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 10,
             "sta": 190,
             "types": [
                 "Dragon",
@@ -5405,7 +5405,7 @@
             "max_cp": 843,
             "max_hp": 75,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 2.5,
             "sta": 80,
             "types": [
                 "Steel",
@@ -5420,7 +5420,7 @@
             "max_cp": 1570,
             "max_hp": 107,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 5,
             "sta": 120,
             "types": [
                 "Steel",
@@ -5435,7 +5435,7 @@
             "max_cp": 3644,
             "max_hp": 138,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 10,
             "sta": 160,
             "types": [
                 "Steel",
@@ -5450,7 +5450,7 @@
             "max_cp": 3087,
             "max_hp": 138,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 9.5,
             "sta": 160,
             "types": [
                 "Rock"
@@ -5464,7 +5464,7 @@
             "max_cp": 3087,
             "max_hp": 138,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 9.5,
             "sta": 160,
             "types": [
                 "Ice"
@@ -5478,7 +5478,7 @@
             "max_cp": 2261,
             "max_hp": 138,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 9.5,
             "sta": 160,
             "types": [
                 "Steel"
@@ -5492,7 +5492,7 @@
             "max_cp": 3377,
             "max_hp": 138,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 10,
             "sta": 160,
             "types": [
                 "Dragon",
@@ -5507,7 +5507,7 @@
             "max_cp": 3644,
             "max_hp": 138,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 10,
             "sta": 160,
             "types": [
                 "Dragon",
@@ -5522,8 +5522,8 @@
             "max_cp": 4074,
             "max_hp": 155,
             "quick_move": "?",
-            "rating": 1.0,
-            "sta": 182,
+            "rating": 10,
+            "sta": 200,
             "types": [
                 "Water"
             ]
@@ -5536,8 +5536,8 @@
             "max_cp": 4074,
             "max_hp": 155,
             "quick_move": "?",
-            "rating": 1.0,
-            "sta": 182,
+            "rating": 10,
+            "sta": 200,
             "types": [
                 "Ground"
             ]
@@ -5550,7 +5550,7 @@
             "max_cp": 4354,
             "max_hp": 178,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 10,
             "sta": 210,
             "types": [
                 "Dragon",
@@ -5565,7 +5565,7 @@
             "max_cp": 3090,
             "max_hp": 170,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 10,
             "sta": 200,
             "types": [
                 "Steel",
@@ -5580,7 +5580,7 @@
             "max_cp": 2749,
             "max_hp": 91,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 10,
             "sta": 100,
             "types": [
                 "Psychic"
@@ -5594,7 +5594,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -5608,7 +5608,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -5622,7 +5622,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass",
@@ -5637,7 +5637,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire"
@@ -5651,7 +5651,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire",
@@ -5666,7 +5666,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire",
@@ -5681,7 +5681,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -5695,7 +5695,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -5709,7 +5709,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water",
@@ -5724,7 +5724,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal",
@@ -5739,7 +5739,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal",
@@ -5754,7 +5754,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal",
@@ -5769,7 +5769,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -5783,7 +5783,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal",
@@ -5798,7 +5798,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug"
@@ -5812,7 +5812,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug"
@@ -5826,7 +5826,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Electric"
@@ -5840,7 +5840,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Electric"
@@ -5854,7 +5854,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Electric"
@@ -5868,7 +5868,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass",
@@ -5883,7 +5883,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass",
@@ -5898,7 +5898,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock"
@@ -5912,7 +5912,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock"
@@ -5926,7 +5926,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock",
@@ -5941,7 +5941,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock",
@@ -5956,7 +5956,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug"
@@ -5970,7 +5970,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -5985,7 +5985,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -6000,7 +6000,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -6015,7 +6015,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -6030,7 +6030,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Electric"
@@ -6044,7 +6044,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -6058,7 +6058,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -6072,7 +6072,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -6086,7 +6086,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -6100,7 +6100,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -6114,7 +6114,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water",
@@ -6129,7 +6129,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -6143,7 +6143,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ghost",
@@ -6158,7 +6158,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ghost",
@@ -6173,7 +6173,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -6187,7 +6187,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -6201,7 +6201,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ghost"
@@ -6215,7 +6215,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dark",
@@ -6230,7 +6230,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -6244,7 +6244,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -6258,7 +6258,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic"
@@ -6272,7 +6272,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Poison",
@@ -6287,7 +6287,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Poison",
@@ -6302,7 +6302,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Steel",
@@ -6317,7 +6317,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Steel",
@@ -6332,7 +6332,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock"
@@ -6346,7 +6346,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic",
@@ -6361,7 +6361,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -6375,7 +6375,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal",
@@ -6390,7 +6390,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ghost",
@@ -6405,7 +6405,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dragon",
@@ -6420,7 +6420,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dragon",
@@ -6435,7 +6435,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dragon",
@@ -6450,7 +6450,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -6464,7 +6464,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fighting"
@@ -6478,7 +6478,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fighting",
@@ -6493,7 +6493,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ground"
@@ -6507,7 +6507,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ground"
@@ -6521,7 +6521,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Poison",
@@ -6536,7 +6536,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Poison",
@@ -6551,7 +6551,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Poison",
@@ -6566,7 +6566,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Poison",
@@ -6581,7 +6581,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -6595,7 +6595,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -6609,7 +6609,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -6623,7 +6623,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water",
@@ -6638,7 +6638,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass",
@@ -6653,7 +6653,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass",
@@ -6668,7 +6668,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dark",
@@ -6683,7 +6683,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Electric",
@@ -6698,7 +6698,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -6712,7 +6712,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ground",
@@ -6727,7 +6727,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -6741,7 +6741,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Electric"
@@ -6755,7 +6755,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire"
@@ -6769,7 +6769,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fairy",
@@ -6784,7 +6784,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -6799,7 +6799,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -6813,7 +6813,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ice"
@@ -6827,7 +6827,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ground",
@@ -6842,7 +6842,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ice",
@@ -6857,7 +6857,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -6871,7 +6871,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic",
@@ -6886,7 +6886,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock",
@@ -6901,7 +6901,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ghost"
@@ -6915,7 +6915,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ice",
@@ -6930,7 +6930,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Electric",
@@ -6945,7 +6945,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic"
@@ -6959,7 +6959,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic"
@@ -6973,7 +6973,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic"
@@ -6987,7 +6987,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Steel",
@@ -7002,7 +7002,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water",
@@ -7017,7 +7017,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire",
@@ -7032,7 +7032,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -7046,7 +7046,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ghost",
@@ -7061,7 +7061,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic"
@@ -7075,7 +7075,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -7089,7 +7089,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -7103,7 +7103,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dark"
@@ -7117,7 +7117,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -7131,7 +7131,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -7145,7 +7145,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic",
@@ -7160,7 +7160,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -7174,7 +7174,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -7188,7 +7188,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -7202,7 +7202,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire"
@@ -7216,7 +7216,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire",
@@ -7231,7 +7231,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire",
@@ -7246,7 +7246,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -7260,7 +7260,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -7274,7 +7274,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -7288,7 +7288,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -7302,7 +7302,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -7316,7 +7316,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -7330,7 +7330,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -7344,7 +7344,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -7358,7 +7358,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dark"
@@ -7372,7 +7372,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dark"
@@ -7386,7 +7386,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -7400,7 +7400,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -7414,7 +7414,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire"
@@ -7428,7 +7428,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire"
@@ -7442,7 +7442,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -7456,7 +7456,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -7470,7 +7470,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic"
@@ -7484,7 +7484,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic"
@@ -7498,7 +7498,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal",
@@ -7513,7 +7513,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal",
@@ -7528,7 +7528,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal",
@@ -7543,7 +7543,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Electric"
@@ -7557,7 +7557,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Electric"
@@ -7571,7 +7571,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock"
@@ -7585,7 +7585,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock"
@@ -7599,7 +7599,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock"
@@ -7613,7 +7613,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic",
@@ -7628,7 +7628,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic",
@@ -7643,7 +7643,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ground"
@@ -7657,7 +7657,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ground",
@@ -7672,7 +7672,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -7686,7 +7686,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fighting"
@@ -7700,7 +7700,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fighting"
@@ -7714,7 +7714,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fighting"
@@ -7728,7 +7728,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -7742,7 +7742,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water",
@@ -7757,7 +7757,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water",
@@ -7772,7 +7772,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fighting"
@@ -7786,7 +7786,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fighting"
@@ -7800,7 +7800,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -7815,7 +7815,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -7830,7 +7830,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -7845,7 +7845,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -7860,7 +7860,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -7875,7 +7875,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -7890,7 +7890,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass",
@@ -7905,7 +7905,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass",
@@ -7920,7 +7920,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -7934,7 +7934,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -7948,7 +7948,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -7962,7 +7962,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ground",
@@ -7977,7 +7977,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ground",
@@ -7992,7 +7992,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ground",
@@ -8007,7 +8007,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire"
@@ -8021,7 +8021,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire"
@@ -8035,7 +8035,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -8049,7 +8049,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -8064,7 +8064,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -8079,7 +8079,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dark",
@@ -8094,7 +8094,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dark",
@@ -8109,7 +8109,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic",
@@ -8124,7 +8124,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ghost"
@@ -8138,7 +8138,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ghost"
@@ -8152,7 +8152,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water",
@@ -8167,7 +8167,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water",
@@ -8182,7 +8182,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock",
@@ -8197,7 +8197,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock",
@@ -8212,7 +8212,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Poison"
@@ -8226,7 +8226,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Poison"
@@ -8240,7 +8240,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dark"
@@ -8254,7 +8254,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dark"
@@ -8268,7 +8268,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -8282,7 +8282,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -8296,7 +8296,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic"
@@ -8310,7 +8310,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic"
@@ -8324,7 +8324,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic"
@@ -8338,7 +8338,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic"
@@ -8352,7 +8352,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic"
@@ -8366,7 +8366,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic"
@@ -8380,7 +8380,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water",
@@ -8395,7 +8395,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water",
@@ -8410,7 +8410,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ice"
@@ -8424,7 +8424,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ice"
@@ -8438,7 +8438,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ice"
@@ -8452,7 +8452,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal",
@@ -8467,7 +8467,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal",
@@ -8482,7 +8482,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Electric",
@@ -8497,7 +8497,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug"
@@ -8511,7 +8511,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -8526,7 +8526,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass",
@@ -8541,7 +8541,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass",
@@ -8556,7 +8556,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water",
@@ -8571,7 +8571,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water",
@@ -8586,7 +8586,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -8600,7 +8600,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -8615,7 +8615,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -8630,7 +8630,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass",
@@ -8645,7 +8645,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass",
@@ -8660,7 +8660,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Steel"
@@ -8674,7 +8674,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Steel"
@@ -8688,7 +8688,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Steel"
@@ -8702,7 +8702,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Electric"
@@ -8716,7 +8716,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Electric"
@@ -8730,7 +8730,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Electric"
@@ -8744,7 +8744,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic"
@@ -8758,7 +8758,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic"
@@ -8772,7 +8772,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ghost",
@@ -8787,7 +8787,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ghost",
@@ -8802,7 +8802,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ghost",
@@ -8817,7 +8817,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dragon"
@@ -8831,7 +8831,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dragon"
@@ -8845,7 +8845,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dragon"
@@ -8859,7 +8859,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ice"
@@ -8873,7 +8873,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ice"
@@ -8887,7 +8887,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ice"
@@ -8901,7 +8901,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug"
@@ -8915,7 +8915,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug"
@@ -8929,7 +8929,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ground",
@@ -8944,7 +8944,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fighting"
@@ -8958,7 +8958,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fighting"
@@ -8972,7 +8972,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dragon"
@@ -8986,7 +8986,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ground",
@@ -9001,7 +9001,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ground",
@@ -9016,7 +9016,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dark",
@@ -9031,7 +9031,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dark",
@@ -9046,7 +9046,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -9060,7 +9060,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal",
@@ -9075,7 +9075,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal",
@@ -9090,7 +9090,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dark",
@@ -9105,7 +9105,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dark",
@@ -9120,7 +9120,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire"
@@ -9134,7 +9134,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -9149,7 +9149,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dark",
@@ -9164,7 +9164,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dark",
@@ -9179,7 +9179,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dark",
@@ -9194,7 +9194,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -9209,7 +9209,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -9224,7 +9224,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Steel",
@@ -9239,7 +9239,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock",
@@ -9254,7 +9254,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass",
@@ -9269,7 +9269,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Flying"
@@ -9283,7 +9283,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Electric",
@@ -9298,7 +9298,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dragon",
@@ -9313,7 +9313,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dragon",
@@ -9328,7 +9328,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ground",
@@ -9343,7 +9343,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dragon",
@@ -9358,7 +9358,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water",
@@ -9373,7 +9373,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal",
@@ -9388,7 +9388,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -9403,7 +9403,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -9417,7 +9417,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -9431,7 +9431,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass",
@@ -9446,7 +9446,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire"
@@ -9460,7 +9460,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire"
@@ -9474,7 +9474,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire",
@@ -9489,7 +9489,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -9503,7 +9503,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -9517,7 +9517,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water",
@@ -9532,7 +9532,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -9546,7 +9546,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal",
@@ -9561,7 +9561,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal",
@@ -9576,7 +9576,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire",
@@ -9591,7 +9591,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire",
@@ -9606,7 +9606,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug"
@@ -9620,7 +9620,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug"
@@ -9634,7 +9634,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -9649,7 +9649,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire",
@@ -9664,7 +9664,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire",
@@ -9679,7 +9679,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fairy"
@@ -9693,7 +9693,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fairy"
@@ -9707,7 +9707,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fairy"
@@ -9721,7 +9721,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -9735,7 +9735,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -9749,7 +9749,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fighting"
@@ -9763,7 +9763,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fighting",
@@ -9778,7 +9778,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -9792,7 +9792,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic"
@@ -9806,7 +9806,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic"
@@ -9820,7 +9820,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Steel",
@@ -9835,7 +9835,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Steel",
@@ -9850,7 +9850,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Steel",
@@ -9865,7 +9865,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fairy"
@@ -9879,7 +9879,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fairy"
@@ -9893,7 +9893,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fairy"
@@ -9907,7 +9907,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fairy"
@@ -9921,7 +9921,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dark",
@@ -9936,7 +9936,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dark",
@@ -9951,7 +9951,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock",
@@ -9966,7 +9966,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock",
@@ -9981,7 +9981,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Poison",
@@ -9996,7 +9996,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Poison",
@@ -10011,7 +10011,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -10025,7 +10025,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -10039,7 +10039,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Electric",
@@ -10054,7 +10054,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Electric",
@@ -10069,7 +10069,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock",
@@ -10084,7 +10084,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock",
@@ -10099,7 +10099,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock",
@@ -10114,7 +10114,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock",
@@ -10129,7 +10129,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fairy"
@@ -10143,7 +10143,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fighting",
@@ -10158,7 +10158,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Electric",
@@ -10173,7 +10173,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock",
@@ -10188,7 +10188,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dragon"
@@ -10202,7 +10202,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dragon"
@@ -10216,7 +10216,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dragon"
@@ -10230,7 +10230,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Steel",
@@ -10245,7 +10245,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ghost",
@@ -10260,7 +10260,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ghost",
@@ -10275,7 +10275,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ghost",
@@ -10290,7 +10290,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ghost",
@@ -10305,7 +10305,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ice"
@@ -10319,7 +10319,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ice"
@@ -10333,7 +10333,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Flying",
@@ -10348,7 +10348,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Flying",
@@ -10363,7 +10363,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fairy"
@@ -10377,7 +10377,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dark",
@@ -10392,7 +10392,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dragon",
@@ -10407,7 +10407,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock",
@@ -10422,7 +10422,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic",
@@ -10437,7 +10437,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire",
@@ -10452,7 +10452,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass",
@@ -10467,7 +10467,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass",
@@ -10482,7 +10482,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass",
@@ -10497,7 +10497,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire"
@@ -10511,7 +10511,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire"
@@ -10525,7 +10525,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire",
@@ -10540,7 +10540,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -10554,7 +10554,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -10568,7 +10568,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water",
@@ -10583,7 +10583,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal",
@@ -10598,7 +10598,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal",
@@ -10613,7 +10613,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal",
@@ -10628,7 +10628,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -10642,7 +10642,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -10656,7 +10656,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug"
@@ -10670,7 +10670,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -10685,7 +10685,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -10700,7 +10700,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fighting"
@@ -10714,7 +10714,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fighting",
@@ -10729,7 +10729,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Flying",
@@ -10747,7 +10747,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -10762,7 +10762,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -10777,7 +10777,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock"
@@ -10791,7 +10791,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock"
@@ -10805,7 +10805,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -10819,7 +10819,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Poison",
@@ -10834,7 +10834,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Poison",
@@ -10849,7 +10849,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ground"
@@ -10863,7 +10863,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ground"
@@ -10877,7 +10877,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water",
@@ -10892,7 +10892,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water",
@@ -10907,7 +10907,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -10921,7 +10921,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -10935,7 +10935,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass",
@@ -10950,7 +10950,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass",
@@ -10965,7 +10965,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Poison",
@@ -10980,7 +10980,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Poison",
@@ -10995,7 +10995,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal",
@@ -11010,7 +11010,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal",
@@ -11025,7 +11025,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -11039,7 +11039,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -11053,7 +11053,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass"
@@ -11067,7 +11067,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fairy"
@@ -11081,7 +11081,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal",
@@ -11096,7 +11096,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fighting"
@@ -11110,7 +11110,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -11125,7 +11125,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -11140,7 +11140,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ghost",
@@ -11155,7 +11155,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ghost",
@@ -11170,7 +11170,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water"
@@ -11184,7 +11184,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -11198,7 +11198,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -11212,7 +11212,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock",
@@ -11227,7 +11227,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal"
@@ -11241,7 +11241,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fire",
@@ -11256,7 +11256,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Electric",
@@ -11271,7 +11271,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ghost",
@@ -11286,7 +11286,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water",
@@ -11301,7 +11301,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Normal",
@@ -11316,7 +11316,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Ghost",
@@ -11331,7 +11331,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dragon"
@@ -11345,7 +11345,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dragon",
@@ -11360,7 +11360,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dragon",
@@ -11375,7 +11375,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Electric",
@@ -11390,7 +11390,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic",
@@ -11405,7 +11405,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass",
@@ -11420,7 +11420,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Water",
@@ -11435,7 +11435,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic"
@@ -11449,7 +11449,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic"
@@ -11463,7 +11463,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic",
@@ -11478,7 +11478,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic",
@@ -11493,7 +11493,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Rock",
@@ -11508,7 +11508,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -11523,7 +11523,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Bug",
@@ -11538,7 +11538,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Electric"
@@ -11552,7 +11552,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Steel",
@@ -11567,7 +11567,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Grass",
@@ -11582,7 +11582,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Dark",
@@ -11597,7 +11597,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Psychic"
@@ -11611,7 +11611,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Steel",
@@ -11626,7 +11626,7 @@
             "max_cp": 1,
             "max_hp": 1,
             "quick_move": "?",
-            "rating": 1.0,
+            "rating": 1,
             "sta": 1,
             "types": [
                 "Fighting",


### PR DESCRIPTION
## Description
Update all ratings based on the base stats of each Pokemon.

Please check those ratings, if they make sense. And tell me, what is maybe weird. :)

## Motivation and Context
Currently, the third Generation was missing any rating.

## How Has This Been Tested?
On own instance with recents_filter_rating set to 6 or 7.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
