### PR TITLE
Hide Pokemon stats and slider in live map

### DIFF
--- a/core/js/pokemon.maps.js
+++ b/core/js/pokemon.maps.js
@@ -15,6 +15,10 @@ function initMap() {
 		var zoom_level = Number(variables['system']['zoom_level']);
 		var pokeimg_suffix = variables['system']['pokeimg_suffix'];
 		var show_encounter_stats = variables['system']['live_show_encounter_stats'];
+
+		if (show_encounter_stats) {
+	        	ivMin = 0;
+                }
             
 		map = new google.maps.Map(document.getElementById('map'), {
 			center: {

--- a/core/json/variables.examples.json
+++ b/core/json/variables.examples.json
@@ -30,6 +30,7 @@
 		"recents_filter"		:	true,
 		"recents_filter_rating"	:	8,
 		"recents_filter_rarity"	:	0.01,
+		"live_show_encounter_stats"     :	true,
 		"captcha_support"		:	false,
 		"iv_numbers"			:	false,
 		"forced_lang"			:	"",

--- a/core/process/aru.php
+++ b/core/process/aru.php
@@ -943,24 +943,29 @@ if ($postRequest != "") {
 				$inmap_pkms_filter = "";
 				$where = " WHERE disappear_time >= UTC_TIMESTAMP() AND pokemon_id = ".$pokemon_id;
 
-				$reqTestIv = "SELECT MAX(individual_attack) AS iv FROM pokemon ".$where;
-				$resultTestIv = $mysqli->query($reqTestIv);
-				$testIv = $resultTestIv->fetch_object();
-				if (isset($_POST['inmap_pokemons']) && ($_POST['inmap_pokemons'] != "")) {
-					foreach ($_POST['inmap_pokemons'] as $inmap) {
-						$inmap_pkms_filter .= "'".$inmap."',";
-					}
-					$inmap_pkms_filter = rtrim($inmap_pkms_filter, ",");
-					$where .= " AND encounter_id NOT IN (".$inmap_pkms_filter.") ";
-				}
-				if ($testIv->iv != null && isset($_POST['ivMin']) && ($_POST['ivMin'] != "")) {
-					$ivMin = mysqli_real_escape_string($mysqli, $_POST['ivMin']);
-					$where .= " AND ((100/45)*(individual_attack+individual_defense+individual_stamina)) >= (".$ivMin.") ";
-				}
-				if ($testIv->iv != null && isset($_POST['ivMax']) && ($_POST['ivMax'] != "")) {
-					$ivMax = mysqli_real_escape_string($mysqli, $_POST['ivMax']);
-					$where .= " AND ((100/45)*(individual_attack+individual_defense+individual_stamina)) <=(".$ivMax.") ";
-				}
+                if (isset($_POST['inmap_pokemons']) && ($_POST['inmap_pokemons'] != "")) {
+                    foreach ($_POST['inmap_pokemons'] as $inmap) {
+                        $inmap_pkms_filter .= "'".$inmap."',";
+                    }
+                    $inmap_pkms_filter = rtrim($inmap_pkms_filter, ",");
+                    $where .= " AND encounter_id NOT IN (".$inmap_pkms_filter.") ";
+                }
+
+                if ($config->system->live_show_encounter_stats) {
+                    $reqTestIv = "SELECT MAX(individual_attack) AS iv FROM pokemon ".$where;
+                    $resultTestIv = $mysqli->query($reqTestIv);
+                    $testIv = $resultTestIv->fetch_object();
+                    
+                    if ($testIv->iv != null && isset($_POST['ivMin']) && ($_POST['ivMin'] != "")) {
+                        $ivMin = mysqli_real_escape_string($mysqli, $_POST['ivMin']);
+                        $where .= " AND ((100/45)*(individual_attack+individual_defense+individual_stamina)) >= (".$ivMin.") ";
+                    }
+                    if ($testIv->iv != null && isset($_POST['ivMax']) && ($_POST['ivMax'] != "")) {
+                        $ivMax = mysqli_real_escape_string($mysqli, $_POST['ivMax']);
+                        $where .= " AND ((100/45)*(individual_attack+individual_defense+individual_stamina)) <=(".$ivMax.") ";
+                    }
+                }
+
 				$req = "SELECT pokemon_id, encounter_id, latitude, longitude, disappear_time,
 						(CONVERT_TZ(disappear_time, '+00:00', '".$time_offset."')) AS disappear_time_real,
 						individual_attack, individual_defense, individual_stamina, move_1, move_2


### PR DESCRIPTION
This commit add a new variable to variables.json under system: `live_show_encounter_stats.`

When set to false, this will hide the IV slider and won't show the IVs and other stats in the livemap view.

This becomes useful when you are running Worldopole but you only want to show the stats in RM (different levels of access).

I didn't update documentation or set a default value for the variable, so probably a rework must be done before merging.

I open this PR to see if this tiny feature is interesting to the Worldopole community.

Best regards