### PR TITLE
Make pokemon page more consistent looking + minor style changes

### DIFF
--- a/core/css/style.css
+++ b/core/css/style.css
@@ -173,6 +173,10 @@ img.unseen{
 	opacity:0.5;
 }
 
+.table>tbody>tr>td, .table>tbody>tr>th, .table>tfoot>tr>td, .table>tfoot>tr>th, .table>thead>tr>td, .table>thead>tr>th {
+    padding: 8px 6px;
+}
+
 .pokemon-single a:hover img	 {
 	background-image: url('../img/blue-hover.png');
 	background-size: 100% 100%;
@@ -564,8 +568,8 @@ raids styles
 	font-size: 2em;
 	font-weight: bold;
 	position: absolute;
-	left: 23px;
-	top: 10px;
+	left: 22px;
+	top: 8px;
 }
 
 #raidsContainer .current, #raidsContainer .upcoming {
@@ -599,14 +603,11 @@ raids styles
 	}
 	#raidsContainer .pokemon-single span {
 		font-size: 1.5em;
-		left: 17px;
-		top: 8px;
+		left: 16px;
+		top: 6px;
 	}
 	#raidsContainer td:nth-child(6) {
 		display: none;
-	}
-	#raidsTable>tbody>tr>td, #raidsTable>tbody>tr>th, #raidsTable>tfoot>tr>td, #raidsTable>tfoot>tr>th, #raidsTable>thead>tr>td, #raidsTable>thead>tr>th {
-		padding: 6px
 	}
 }
 

--- a/pages/pokemon.page.php
+++ b/pages/pokemon.page.php
@@ -96,11 +96,11 @@
 		<div class="table-responsive">
 		<table class="table">
             <tr>
-                <td class="col-md-8 col-xs-8"><strong><?= $locales->POKEMON_GEN ?> :</strong></td>
+                <td class="col-md-8 col-xs-8"><strong><?= $locales->POKEMON_GEN ?></strong></td>
                 <td class="col-md-4 col-xs-4"><?= $pokemon->gen ?></td>
             </tr>
 			<tr>
-				<td class="col-md-8 col-xs-8"><strong><?= $locales->POKEMON_SEEN ?> :</strong></td>
+				<td class="col-md-8 col-xs-8"><strong><?= $locales->POKEMON_SEEN ?></strong></td>
 				<td class="col-md-4 col-xs-4">
 
 				<?php
@@ -118,18 +118,18 @@
 				</td>
 			</tr>
 			<tr>
-				<td class="col-md-8 col-xs-8"><strong><?= $locales->POKEMON_AMOUNT ?> :</strong></td>
+				<td class="col-md-8 col-xs-8"><strong><?= $locales->POKEMON_AMOUNT ?></strong></td>
 				<td class="col-md-4 col-xs-4"><?= $pokemon->spawn_count ?> <?= $locales->SEEN ?></td>
 			</tr>
 			<tr>
-				<td class="col-md-8 col-xs-8"><strong><?= $locales->POKEMON_RATE ?> :</strong></td>
+				<td class="col-md-8 col-xs-8"><strong><?= $locales->POKEMON_RATE ?></strong></td>
 				<td class="col-md-4 col-xs-4"><?= $pokemon->spawns_per_day ?> / <?= $locales->DAY ?></td>
 			</tr>
 			<tr>
 				<td class="col-md-8 col-xs-8">
                     <?php
 					if (isset($pokemon->protected_gyms)) {
-						echo "<strong>".$locales->POKEMON_GYM.$pokemon->name."</strong> :";
+						echo "<strong>".$locales->POKEMON_GYM.$pokemon->name."</strong>";
 					} ?>
                 </td>
 				<td class="col-md-4 col-xs-4">
@@ -147,7 +147,7 @@
 		<div class="table-responsive">
 		<table class="table">
 			<tr>
-				<td class="col-md-8 col-xs-8"><strong><?= $locales->POKEMON_RAID_SEEN ?> :</strong></td>
+				<td class="col-md-8 col-xs-8"><strong><?= $locales->POKEMON_RAID_SEEN ?></strong></td>
 				<td class="col-md-4 col-xs-4">
 
                     <?php
@@ -165,15 +165,15 @@
 				</td>
 			</tr>
 			<tr>
-				<td class="col-md-8 col-xs-8"><strong><?= $locales->POKEMON_RAID_AMOUNT ?> :</strong></td>
+				<td class="col-md-8 col-xs-8"><strong><?= $locales->POKEMON_RAID_AMOUNT ?></strong></td>
 				<td class="col-md-4 col-xs-4"><?= $pokemon->raid_count ?> <?= $locales->SEEN ?></td>
 			</tr>
 			<tr>
-				<td class="col-md-8 col-xs-8"><strong><?= $locales->POKEMON_QUICK ?> :</strong></td>
+				<td class="col-md-8 col-xs-8"><strong><?= $locales->POKEMON_QUICK ?></strong></td>
 				<td class="col-md-4 col-xs-4"><?= $pokemon->quick_move ?></td>
 			</tr>
 			<tr>
-				<td class="col-md-8 col-xs-8"><strong><?= $locales->POKEMON_SPECIAL ?> :</strong> </td>
+				<td class="col-md-8 col-xs-8"><strong><?= $locales->POKEMON_SPECIAL ?></strong> </td>
 				<td class="col-md-4 col-xs-4"><?= $pokemon->charge_move ?></td>
 			</tr>
 
@@ -183,11 +183,11 @@
 </div>
 
 
-
 <div class="row area text-center subnav">
 	<div class="btn-group" role="group">
 		<a class="btn btn-default page-scroll" href="pokemon/<?= $pokemon->id ?>#where"><i class="fa fa-map-marker"></i> <?= $locales->POKEMON_MAP ?></a>
 		<a class="btn btn-default page-scroll" href="pokemon/<?= $pokemon->id ?>#stats"><i class="fa fa-pie-chart"></i> <?= $locales->POKEMON_STATS ?></a>
+		<a class="btn btn-default page-scroll" href="pokemon/<?= $pokemon->id ?>#evolve"><i class="fa fa-flash"></i> <?= $locales->POKEMON_EVOLUTIONS ?></a>
 		<a class="btn btn-default page-scroll" href="pokemon/<?= $pokemon->id ?>#family"><i class="fa fa-share-alt"></i> <?= $locales->POKEMON_FAMILY ?></a>
 		<a class="btn btn-default page-scroll" href="pokemon/<?= $pokemon->id ?>#top50"><i class="fa fa-list"></i> Top50</a>
 		<a class="btn btn-default page-scroll" href="pokemon/<?= $pokemon->id ?>#trainer"><i class="fa fa-users"></i> <?= $locales->TRAINERS ?></a>
@@ -195,14 +195,9 @@
 </div>
 
 
-
-
 <div class="row" id="where">
-
 	<div class="col-md-12">
-
 		<h2 class="text-center sub-title"><?= $locales->POKEMON_WHERE ?> <?= $pokemon->name ?>?</h2>
-
 	</div>
 </div>
 <div class="row text-center subnav">
@@ -279,17 +274,17 @@
 
 	</div>
 
-	<!-- Tree -->
-	
-	<?php
-	$tree = array($pokemon->tree);
-	$depth = get_depth($tree);
-	?>
+</div>
 
-	<h3 class="col-md-12 text-center sub-title"><strong><?= $locales->POKEMON_EVOLUTIONS ?></strong></h3>
+<div class="row area" id="evolve">
+
+	<h2 class="text-center sub-title"><strong><?= $pokemon->name ?> </strong><?= $locales->POKEMON_EVOLUTIONS ?></h2>
+
 	<div class="col-md-12 flex-container-tree results">
 
 		<?php
+		$tree = array($pokemon->tree);
+		$depth = get_depth($tree);
 		$skip = false;
 		for ($i = 0; $i < $depth; $i++) {
 			$i_id = intval(($i + 1) / 2);


### PR DESCRIPTION
## Description
Changes in pokemon page:
- Get rid of those colons
- Add quick link to evolutions section
- Make the evolutions section consistent looking like the other ones

Style changes:
- Reduce some padding to get some more space on mobile

## Screenshots (if appropriate):
Before:
![bildschirmfoto 2018-02-02 um 22 33 04](https://user-images.githubusercontent.com/727517/35755823-1958ea7a-0869-11e8-9cf3-d982e0ad9585.png)
![bildschirmfoto 2018-02-02 um 22 33 13](https://user-images.githubusercontent.com/727517/35755824-1acb832c-0869-11e8-9e97-f2a1ca087286.png)

After:
![bildschirmfoto 2018-02-02 um 22 32 16](https://user-images.githubusercontent.com/727517/35755826-1d6313a2-0869-11e8-8ae9-bfb74906fdb0.png)
![bildschirmfoto 2018-02-02 um 22 32 55](https://user-images.githubusercontent.com/727517/35755829-1f109828-0869-11e8-9c94-e2088ae4eef4.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
