### PR TITLE
Fix name parameter with special chars

### DIFF
--- a/core/js/gymhistory.content.js
+++ b/core/js/gymhistory.content.js
@@ -1,6 +1,20 @@
 /** global: gymName */
 
 $(function () {
+	function htmlspecialchars_decode(string) {
+		var escapeMap = {
+			"&amp;": "&",
+			"&lt;": "<",
+			"&gt;": ">",
+			"&quot;": "\"",
+			"&#39;": "'",
+			"&#039;": "'"
+		};
+		return String(string).replace(/&(amp|lt|gt|quot|#0?39);/gi, function (s) {
+			return escapeMap[s] || s;
+		});
+	}
+
 	$.getJSON("core/json/variables.json", function(variables) {
 		var pokeimg_suffix = variables['system']['pokeimg_suffix'];
 		var hide_cp_changes = variables['system']['gymhistory_hide_cp_changes'];
@@ -11,7 +25,7 @@ $(function () {
 		var teamSelector = ''; //''=all; 0=neutral; 1=Blue; 2=Red; 3=Yellow
 		var rankingFilter = 0; //0=Level & Gyms; 1=Level; 2=Gyms
 
-		$('input#name').filter(':visible').val(gymName);
+		$('input#name').filter(':visible').val(htmlspecialchars_decode(gymName));
 
 		$('#loadMoreButton').click(function () {
 			loadGyms(page, $('input#name').filter(':visible').val(), teamSelector, rankingFilter, pokeimg_suffix, hide_cp_changes, true);

--- a/core/js/trainer.content.js
+++ b/core/js/trainer.content.js
@@ -1,5 +1,18 @@
 /** global: trainerName */
 $(function() {
+	function htmlspecialchars_decode(string) {
+		var escapeMap = {
+			"&amp;": "&",
+			"&lt;": "<",
+			"&gt;": ">",
+			"&quot;": "\"",
+			"&#39;": "'",
+			"&#039;": "'"
+		};
+		return String(string).replace(/&(amp|lt|gt|quot|#0?39);/gi, function (s) {
+			return escapeMap[s] || s;
+		});
+	}
 
 	$.getJSON('core/json/variables.json', function(variables) {
 		var pokeimg_suffix = variables['system']['pokeimg_suffix'];
@@ -10,7 +23,7 @@ $(function() {
 		var teamSelector = 0; //0=all;1=Blue;2=Red;3=Yellow
 		var rankingFilter = 0; //0=Level & Gyms; 1=Level; 2=Gyms
 
-		$('input#name').filter(':visible').val(trainerName);
+		$('input#name').filter(':visible').val(htmlspecialchars_decode(trainerName));
 		loadTrainers(page, $('input#name').filter(':visible').val(), null, null, pokeimg_suffix, true, iv_numbers);
 		if ($('input#name')) {
 			$('input#name').filter(':visible').val() != '' ? $('#trainersGraph').hide() : $('#trainersGraph').show();

--- a/pages/gymhistory.page.php
+++ b/pages/gymhistory.page.php
@@ -68,8 +68,8 @@
 <script type="text/javascript">
 <?=
 $gymName = "";
-if (isset($_GET['name']) && $_GET['name']!="") {
-	$gymName = htmlentities($_GET['name']);
+if (isset($_GET['name'])) {
+	$gymName = htmlspecialchars($_GET['name'], ENT_QUOTES);
 }
 ?>
 var gymName = "<?= $gymName ?>";

--- a/pages/trainer.page.php
+++ b/pages/trainer.page.php
@@ -102,11 +102,10 @@
 <script type="text/javascript">
 <?=
 $trainerName = "";
-if (isset($_GET['name']) && $_GET['name'] != "") {
-	$trainerName = htmlentities($_GET['name']);
+if (isset($_GET['name'])) {
+	$trainerName = htmlspecialchars($_GET['name'], ENT_QUOTES);
 }
 
 ?>
-	var trainerName = "<?= $trainerName ?>";
-
+var trainerName = "<?= $trainerName ?>";
 </script>


### PR DESCRIPTION
## Description
Use htmlspecialchars to encode passed 'name' parameter to prevent XSS attacks.
This should not break when passing accented chars.

## Motivation and Context
Currently, passed gym and trainer names with accented chars break the search. See #361

## How Has This Been Tested?
Own instance.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
