### PR TITLE
Fix cron jobs for pokedex counts and nests

### DIFF
--- a/core/cron/nests.cron.php
+++ b/core/cron/nests.cron.php
@@ -9,17 +9,16 @@
 
 $pokemon_exclude_sql = "";
 if (!empty($config->system->nest_exclude_pokemon)) {
-	$pokemon_exclude_sql = "AND p.pokemon_id NOT IN (".implode(",", $config->system->nest_exclude_pokemon).")";
+	$pokemon_exclude_sql = "AND pokemon_id NOT IN (".implode(",", $config->system->nest_exclude_pokemon).")";
 }
 
-$req = "SELECT p.pokemon_id, max(p.latitude) AS latitude, max(p.longitude) AS longitude, count(p.pokemon_id) AS total_pokemon, s.kind, s.latest_seen
-        FROM pokemon p 
-        INNER JOIN spawnpoint s ON (p.spawnpoint_id = s.id) 
-        WHERE p.disappear_time > UTC_TIMESTAMP() - INTERVAL 24 HOUR 
-        ".$pokemon_exclude_sql." 
-        GROUP BY p.spawnpoint_id, p.pokemon_id 
-        HAVING count(p.pokemon_id) >= 6 
-        ORDER BY p.pokemon_id";
+$req = "SELECT spawnpoint_id, pokemon_id, max(latitude) AS latitude, max(longitude) AS longitude, count(pokemon_id) AS total_pokemon
+        FROM pokemon
+        WHERE disappear_time > (UTC_TIMESTAMP() - INTERVAL 24 HOUR)
+        ".$pokemon_exclude_sql."
+        GROUP BY spawnpoint_id, pokemon_id
+        HAVING count(pokemon_id) >= 6
+        ORDER BY pokemon_id";
 $result = $mysqli->query($req);
 
 while ($data = $result->fetch_object()) {
@@ -27,12 +26,14 @@ while ($data = $result->fetch_object()) {
 	$nests['c'] = $data->total_pokemon;
 	$nests['lat'] = $data->latitude;
 	$nests['lng'] = $data->longitude;
-	$starttime = $data->latest_seen - substr_count($data->kind, "s") * 900;
-	if ($starttime < 0) {
-		$starttime = 3600 + $starttime;
-	}
-	$nests['st'] = sprintf('%02d', floor($starttime / 60));
-	$nests['et'] = sprintf('%02d', floor($data->latest_seen / 60));
+	// $starttime = $data->latest_seen - substr_count($data->kind, "s") * 900;
+	// if ($starttime < 0) {
+	// 	$starttime = 3600 + $starttime;
+	// }
+	// $nests['st'] = sprintf('%02d', floor($starttime / 60));
+	// $nests['et'] = sprintf('%02d', floor($data->latest_seen / 60));
+	$nests['st'] = '00';
+	$nests['et'] = '00';
 
 	// Add the data to array
 	$nestsdatas[] = $nests;


### PR DESCRIPTION
## Description
Due to other mapping tools now available, the spawn points are tracked differently and break the current jobs.
This PR fixes this by not using the spawn points table anymore.
Additionally, this gives an enormous performance boost for the jobs due to no more heavy JOINs.

What we currently loose is the start and end times on the nest page.
I need to figure out a new way how to calculate them.

## How Has This Been Tested?
Tested on own instance with standard RM DB.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
